### PR TITLE
Make join/part messages inline-block

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -59,7 +59,7 @@
     {{#each messages}}{{scrollHack}}
       {{#if message.presence}}
 <div class="bb-message-presence {{message.presence}}" title={{body}}>
-  {{gravatar id=email image="wavatar" size=16 }}{{message.nick}}
+  {{gravatar id=email image="wavatar" size=14 }}{{message.nick}}
 </div>
       {{else}}{{#if message.system}}
 <div class="bb-message-system">

--- a/chat.html
+++ b/chat.html
@@ -57,7 +57,11 @@
       <p align="center">Start of chat log.</p>
     {{/if}}{{/if}}{{/if}}
     {{#each messages}}{{scrollHack}}
-      {{#if message.system}}
+      {{#if message.presence}}
+<div class="bb-message-presence {{message.presence}}" title={{body}}>
+  {{gravatar id=email image="wavatar" size=16 }}{{message.nick}}
+</div>
+      {{else}}{{#if message.system}}
 <div class="bb-message-system">
    <div class="pull-right timestamp">{{pretty_ts message.timestamp}}</div>
      {{body}}
@@ -81,7 +85,7 @@
     {{body}}
   </div>
 </div>
-      {{/if}}{{/if}}
+      {{/if}}{{/if}}{{/if}}
       {{#if isLastRead message.timestamp}}
 <div class="bb-message-last-read">read</div>
       {{/if}}

--- a/chat.less
+++ b/chat.less
@@ -90,16 +90,19 @@
   }
   .bb-message-presence {
     display: inline-block;
+    padding-right: 10px;
     &:before {
       .glyphicon;
       content: " ";
-      padding-top: 1px;
     }
     &.join:before {
       background-position: -408px -96px;
     }
     &.part:before {
       background-position: -433px -96px;
+    }
+    & > img {
+      padding-right: 3px;
     }
   }
   .bb-message-system {

--- a/chat.less
+++ b/chat.less
@@ -88,6 +88,20 @@
     }
     &.media:after { border-right-color: @bb-message-pm-color; }
   }
+  .bb-message-presence {
+    display: inline-block;
+    &:before {
+      .glyphicon;
+      content: " ";
+      padding-top: 1px;
+    }
+    &.join:before {
+      background-position: -408px -96px;
+    }
+    &.part:before {
+      background-position: -433px -96px;
+    }
+  }
   .bb-message-system {
     color: #888;
     font-size: 12px;

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -261,6 +261,7 @@ if Meteor.isServer
 #   system: boolean (true for system messages, false for user messages)
 #   action: boolean (true for /me commands)
 #   oplog:  boolean (true for semi-automatic operation log message)
+#   presence: optional string ('join'/'part' for presence-change only)
 #   to:   destination of pm (optional)
 #   room_name: "<type>/<id>", ie "puzzle/1", "round/1".
 #                             "general/0" for main chat.
@@ -467,8 +468,9 @@ if Meteor.isServer
       return if presence.room_name is 'oplog/0'
       Messages.insert
         system: true
-        nick: ''
+        nick: n
         to: null
+        presence: 'join'
         body: "#{name} joined the room."
         bodyIsHtml: false
         room_name: presence.room_name
@@ -482,8 +484,9 @@ if Meteor.isServer
       return if presence.room_name is 'oplog/0'
       Messages.insert
         system: true
-        nick: ''
+        nick: n
         to: null
+        presence: 'part'
         body: "#{name} left the room."
         bodyIsHtml: false
         room_name: presence.room_name

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -468,7 +468,7 @@ if Meteor.isServer
       return if presence.room_name is 'oplog/0'
       Messages.insert
         system: true
-        nick: n
+        nick: presence.nick
         to: null
         presence: 'join'
         body: "#{name} joined the room."
@@ -484,7 +484,7 @@ if Meteor.isServer
       return if presence.room_name is 'oplog/0'
       Messages.insert
         system: true
-        nick: n
+        nick: presence.nick
         to: null
         presence: 'part'
         body: "#{name} left the room."


### PR DESCRIPTION
This makes consecutive ones collapse into a single or small number of lines, saving space when there's a mass join or exodus, including after a server restart.