### PR TITLE
Backoff on Drive api when rate limited

### DIFF
--- a/server/drive.coffee
+++ b/server/drive.coffee
@@ -42,23 +42,24 @@ userRateExceeded = (error) ->
       return true
   return false
 
-delays = [100, 250, 500, 1000, 2000]
+delays = [100, 250, 500, 1000, 2000, 5000, 10000]
 
-afterDelay = Meteor.wrapAsync (ix, base, name, params, auth, callback) ->
+afterDelay = (ix, base, name, params, callback) ->
   try
-    r = Gapi.exec base, name, params, auth
+    r = Gapi.exec base, name, params 
     callback null, r
   catch error
     if ix >= delays.length or not userRateExceeded(error)
       callback error, null
       return
+    console.warn "Rate limited for #{name}; Will retry after #{delays[ix]}ms"
     later = ->
-      afterDelay ix+1, base, name, params, auth, callback
+      afterDelay ix+1, base, name, params, callback
     Meteor.setTimeout later, delays[ix]
     
 
-apiThrottle = Meteor.wrapAsync (base, name, params, auth, callback) ->
-  afterDelay 0, base, name, params, auth, callback
+apiThrottle = Meteor.wrapAsync (base, name, params, callback) ->
+  afterDelay 0, base, name, params, callback
 
 ensureFolder = (name, parent) ->
   # check to see if the folder already exists

--- a/server/drive.coffee
+++ b/server/drive.coffee
@@ -35,9 +35,34 @@ wrapCheck = (f, type) ->
     return unless checkAuth type
     f.apply(this, arguments)
 
+userRateExceeded = (error) ->
+  return false unless error.code == 403
+  for subError in error.errors
+    if subError.domain is "usageLimits" and subError.reason is "userRateLimitExceeded"
+      return true
+  return false
+
+delays = [100, 250, 500, 1000, 2000]
+
+afterDelay = Meteor.wrapAsync (ix, base, name, params, auth, callback) ->
+  try
+    r = Gapi.exec base, name, params, auth
+    callback null, r
+  catch error
+    if ix >= delays.length or not userRateExceeded(error)
+      callback error, null
+      return
+    later = ->
+      afterDelay ix+1, base, name, params, auth, callback
+    Meteor.setTimeout later, delays[ix]
+    
+
+apiThrottle = Meteor.wrapAsync (base, name, params, auth, callback) ->
+  afterDelay 0, base, name, params, auth, callback
+
 ensureFolder = (name, parent) ->
   # check to see if the folder already exists
-  resp = Gapi.exec drive.children, 'list',
+  resp = apiThrottle drive.children, 'list',
     folderId: parent or 'root'
     q: "title=#{quote name}"
     maxResults: 1
@@ -49,7 +74,7 @@ ensureFolder = (name, parent) ->
       title: name
       mimeType: GDRIVE_FOLDER_MIME_TYPE
     resource.parents = [id: parent] if parent
-    resource = Gapi.exec drive.files, 'insert',
+    resource = apiThrottle drive.files, 'insert',
       resource: resource
   # give the new folder the right permissions
   ensurePermissions(resource.id)
@@ -82,12 +107,12 @@ ensurePermissions = (id) ->
     role: 'writer'
     type: 'anyone'
   ]
-  resp = Gapi.exec drive.permissions, 'list', (fileId: id)
+  resp = apiThrottle drive.permissions, 'list', (fileId: id)
   perms.forEach (p) ->
     # does this permission already exist?
     exists = resp.items.some (pp) -> samePerm(p, pp)
     unless exists
-      Gapi.exec drive.permissions, 'insert',
+      apiThrottle drive.permissions, 'insert',
         fileId: id
         resource: p
   'ok'
@@ -95,7 +120,7 @@ ensurePermissions = (id) ->
 createPuzzle = (name) ->
   folder = ensureFolder name, rootFolder
   # is the spreadsheet already there?
-  spreadsheet = (Gapi.exec drive.children, 'list',
+  spreadsheet = (apiThrottle drive.children, 'list',
     folderId: folder.id
     q: "title=#{quote WORKSHEET_NAME name} and mimeType=#{quote GDRIVE_SPREADSHEET_MIME_TYPE}"
     maxResults: 1
@@ -106,7 +131,7 @@ createPuzzle = (name) ->
       title: WORKSHEET_NAME name
       mimeType: XLSX_MIME_TYPE
       parents: [id: folder.id]
-    spreadsheet = Gapi.exec drive.files, 'insert',
+    spreadsheet = apiThrottle drive.files, 'insert',
       convert: true
       body: spreadsheet # this is only necessary due to bug in gapi, afaict
       resource: spreadsheet
@@ -120,14 +145,14 @@ createPuzzle = (name) ->
   }
 
 findPuzzle = (name) ->
-  resp = Gapi.exec drive.children, 'list',
+  resp = apiThrottle drive.children, 'list',
     folderId: rootFolder
     q: "title=#{quote name} and mimeType=#{quote GDRIVE_FOLDER_MIME_TYPE}"
     maxResults: 1
   folder = resp.items[0]
   return null unless folder?
   # look for spreadsheet
-  resp = Gapi.exec drive.children, 'list',
+  resp = apiThrottle drive.children, 'list',
     folderId: folder.id
     q: "title=#{quote WORKSHEET_NAME name}"
     maxResults: 1
@@ -140,7 +165,7 @@ listPuzzles = ->
   results = []
   resp = {}
   loop
-    resp = Gapi.exec drive.children, 'list',
+    resp = apiThrottle drive.children, 'list',
       folderId: rootFolder
       q: "mimeType=#{quote GDRIVE_FOLDER_MIME_TYPE}"
       maxResults: MAX_RESULTS
@@ -150,12 +175,12 @@ listPuzzles = ->
   results
 
 renamePuzzle = (name, id, spreadId) ->
-  Gapi.exec drive.files, 'patch',
+  apiThrottle drive.files, 'patch',
     fileId: id
     resource:
       title: name
   if spreadId?
-    Gapi.exec drive.files, 'patch',
+    apiThrottle drive.files, 'patch',
       fileId: spreadId
       resource:
         title: (WORKSHEET_NAME name)
@@ -166,7 +191,7 @@ rmrfFolder = (id) ->
     resp = {}
     loop
       # delete subfolders
-      resp = Gapi.exec drive.children, 'list',
+      resp = apiThrottle drive.children, 'list',
         folderId: id
         q: "mimeType=#{quote GDRIVE_FOLDER_MIME_TYPE}"
         maxResults: MAX_RESULTS
@@ -176,22 +201,22 @@ rmrfFolder = (id) ->
       break unless resp.nextPageToken?
     loop
       # delete non-folder stuff
-      resp = Gapi.exec drive.children, 'list',
+      resp = apiThrottle drive.children, 'list',
         folderId: id
         q: "mimeType!=#{quote GDRIVE_FOLDER_MIME_TYPE}"
         maxResults: MAX_RESULTS
         pageToken: resp.nextPageToken
       resp.items.forEach (item) ->
-        Gapi.exec drive.files, 'delete', (fileId: item.id)
+        apiThrottle drive.files, 'delete', (fileId: item.id)
       break unless resp.nextPageToken?
     # are we done? look for remaining items owned by us
-    resp = Gapi.exec drive.children, 'list',
+    resp = apiThrottle drive.children, 'list',
       folderId: id
       q: "#{quote EMAIL} in owners"
       maxResults: 1
     break if resp.items.length is 0
   # folder empty; delete the folder and we're done
-  Gapi.exec drive.files, 'delete', (fileId: id)
+  apiThrottle drive.files, 'delete', (fileId: id)
   'ok'
 
 deletePuzzle = (id) -> rmrfFolder(id)


### PR DESCRIPTION
We have a 1000 queries per 100 seconds quota, but it seems to be applied as 10 queries per second. When starting multiple copies of the blackboard software at once, they can all try to ensure the drive folder exists and has the right permissions at the same time, which can exhaust this limit. This does an exponential backoff in the hopes that the quota will reset.
Fixes #22 