### PR TITLE
Enable desktop notifications from Oplog messages

### DIFF
--- a/blackboard.html
+++ b/blackboard.html
@@ -34,13 +34,30 @@
     Compact mode
   </label>
 </div>
-    {{/unless}}
+{{/unless}}
 </div>
     <h1 align="center" class="bb-blackboard-h1">
       <span class="bb-no-wrap">
       <span class="bb-hide-when-narrower">Codex</span></span> <span class="bb-hide-when-narrow">Puzzle </span><span class="bb-no-wrap">Blackboard
       </span>
     </h1>
+    {{#unless canEdit}}
+    {{#if notificationsEnabled}}
+    <div id="notification-controls">
+      <div class="label">Enabled notifications:</div>
+      <div>
+      {{#each notificationStreams}}
+        <label for="bb-notification-{{name}}">
+          <input type="checkbox" id="bb-notification-{{name}}"
+                 data-notification-stream="{{name}}"
+                 checked="{{notificationStreamEnabled name}}">
+        {{label}}
+        </label>
+      {{/each}}
+      </div>
+    </div>
+    {{/if}}
+    {{/unless}}
   <table class="table table-bordered table-condensed bb-puzzle">
   <thead>
     {{#unless compactMode}}

--- a/blackboard.less
+++ b/blackboard.less
@@ -292,6 +292,21 @@ body {
     position: relative;
     z-index: 99;
   }
+  #notification-controls {
+    clear: both;
+    display: flex;
+    label {
+      display: inline-block;
+      margin: initial;
+      white-space: nowrap;
+    }
+    input[type=checkbox] {
+      margin: initial;
+      margin-right: 2px;
+      margin-left: 5px;
+      vertical-align: initial;
+    }
+  }
   .bb-roundgroup-buttons, .bb-round-buttons {
     margin-top: 5px;
   }

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -60,6 +60,22 @@ Template.blackboard.helpers
   hideStatus: -> Session.get 'hideStatus'
   compactMode: compactMode
 
+# Notifications
+notificationStreams = [
+  {name: 'newpuzzles', label: 'New Puzzles'}
+  {name: 'announcements', label: 'Announcements'}
+  {name: 'callins', label: "Call-Ins"}
+  {name: 'answers', label: "Answers"}
+  {name: 'stuck', label: "Stuck Puzzles"}
+]
+Template.blackboard.helpers
+  notificationStreams: notificationStreams
+  notificationsEnabled: -> Session.get 'notifications'
+  notificationStreamEnabled: (stream) -> share.notification.get stream
+Template.blackboard.events
+  "change #notification-controls [data-notification-stream]": (event, template) ->
+    share.notification.set event.target.dataset.notificationStream, event.target.checked
+
 ############## groups, rounds, and puzzles ####################
 Template.blackboard.helpers
   roundgroups: ->

--- a/client/chat.coffee
+++ b/client/chat.coffee
@@ -109,6 +109,11 @@ Template.chat.helpers
     type = Session.get 'type'
     type isnt 'general' and (model.collection(type)?.findOne Session.get("id"))
 
+nickEmail = (nick) ->
+  cn = model.canonical(nick)
+  n = model.Nicks.findOne canon: cn
+  return model.getTag(n, 'Gravatar') or "#{cn}@#{settings.DEFAULT_HOST}"
+
 # Template Binding
 Template.messages.helpers
   room_name: -> Session.get('room_name')
@@ -140,10 +145,7 @@ Template.messages.helpers
         message: m
         isBot: m.nick is 'codexbot' and m.to is null
 
-  email: ->
-    cn = model.canonical(this.message.nick)
-    n = model.Nicks.findOne canon: cn
-    return model.getTag(n, 'Gravatar') or "#{cn}@#{settings.DEFAULT_HOST}"
+  email: -> nickEmail this.message.nick
   body: ->
     body = this.message.body or ''
     unless this.message.bodyIsHtml
@@ -648,6 +650,7 @@ share.chat =
   cleanupChat: cleanupChat
   hideMessageAlert: hideMessageAlert
   joinRoom: joinRoom
+  nickEmail: nickEmail
   # pagination helpers
   pageForTimestamp: pageForTimestamp
   messagesForPage: messagesForPage

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -294,9 +294,10 @@ if DO_BATCH_PROCESSING
 # Messages which are part of the operation log have `nick`, `message`,
 # and `timestamp` set to describe what was done, when, and by who.
 # They have `system=false`, `action=true`, `oplog=true`, `to=null`,
-# and `room_name="oplog/0"`.  They also have two additional fields,
+# and `room_name="oplog/0"`.  They also have three additional fields:
 # `type` and `id`, which give a mongodb reference to the object
-# modified so we can hyperlink to it.
+# modified so we can hyperlink to it, and stream, which maps to the
+# JS Notification API 'tag' for deduping and selective muting.
 Messages = BBCollection.messages = new Mongo.Collection "messages"
 OldMessages = BBCollection.oldmessages = new Mongo.Collection "oldmessages"
 if DO_BATCH_PROCESSING
@@ -470,6 +471,21 @@ pretty_collection = (type) ->
 getTag = (object, name) ->
   (tag.value for tag in (object?.tags or []) when tag.canon is canonical(name))[0]
 
+oplog = (message, type="", id="", who="", stream="") ->
+  Messages.insert
+    room_name: 'oplog/0'
+    nick: canonical(who)
+    timestamp: UTCNow()
+    body: message
+    bodyIsHtml: false
+    type:type
+    id:id 
+    oplog: true
+    action: true
+    system: false
+    to: null
+    stream: stream
+
 # canonical names: lowercases, all non-alphanumerics replaced with '_'
 canonical = (s) ->
   s = s.toLowerCase().replace(/^\s+/, '').replace(/\s+$/, '') # lower, strip
@@ -532,20 +548,6 @@ spread_id_to_link = (id) ->
         check o[k], pattern[k]
       true
 
-  oplog = (message, type="", id="", who="") ->
-    Messages.insert
-      room_name: 'oplog/0'
-      nick: canonical(who)
-      timestamp: UTCNow()
-      body: message
-      bodyIsHtml: false
-      type:type
-      id:id
-      oplog: true
-      action: true
-      system: false
-      to: null
-
   newObject = (type, args, extra, options={}) ->
     check args, ObjectWith
       name: NonEmptyString
@@ -569,7 +571,9 @@ spread_id_to_link = (id) ->
         return collection(type).findOne({canon:canonical(args.name)})
       throw error # something went wrong, who knows what, pass it on
     unless options.suppressLog
-      oplog "Added", type, object._id, args.who
+      oplog "Added", type, object._id, args.who, \
+          if type in ['puzzles', 'rounds', 'roundgroups'] \
+              then 'newpuzzles' else ''
     return object
 
   renameObject = (type, args, options={}) ->
@@ -906,7 +910,8 @@ spread_id_to_link = (id) ->
         if round?
           msg.room_name = "rounds/#{round._id}"
           Meteor.call "newMessage", msg
-      oplog "New answer #{args.answer} submitted for", args.type, id, args.who
+      oplog "New answer #{args.answer} submitted for", args.type, id, \
+          args.who, 'callins'
 
     newQuip: (args) ->
       check args, ObjectWith
@@ -1016,7 +1021,8 @@ spread_id_to_link = (id) ->
       callin = CallIns.findOne(args.id)
       throw new Meteor.Error(400, "bad callin") unless callin
       unless args.suppressLog
-        oplog "Canceled call-in of #{callin.answer} for", callin.type, callin.target, args.who
+        oplog "Canceled call-in of #{callin.answer} for", callin.type, \
+            callin.target, args.who
       deleteObject "callins",
         id: args.id
         who: args.who
@@ -1242,16 +1248,18 @@ spread_id_to_link = (id) ->
         return "Couldn't find #{id} in #{args.type}"
       if getTag(puzz, 'answer')?
         return "#{puzz.name} is already answered"
+      newStuck = args.value or 'stuck'
       oldStuck = getTag(puzz, 'stuck')
       setTagInternal
         object: id
         type: args.type
         name: 'stuck'
-        value: args.value or 'stuck'
+        value: newStuck
         who: args.who
         now: UTCNow()
       if oldStuck?
         return
+      oplog "Requested help (#{newStuck}) on", args.type, id, args.who, 'stuck'
       body = "has requested help getting unstuck"
       if args.value?
         body = "#{body} (#{UI._escape args.value})"
@@ -1423,7 +1431,7 @@ spread_id_to_link = (id) ->
         solved_by: canonical(args.who)
         touched: now
         touched_by: canonical(args.who)
-      oplog "Found an answer to", args.type, id, args.who
+      oplog "Found an answer to", args.type, id, args.who, 'answers'
       # cancel any entries on the call-in queue for this puzzle
       for c in CallIns.find(type: args.type, target: id).fetch()
         Meteor.call 'cancelCallIn',
@@ -1453,7 +1461,8 @@ spread_id_to_link = (id) ->
           backsolve: !!args.backsolve
           provided: !!args.provided
 
-      oplog "Incorrect answer #{args.answer} for", args.type, id, args.who
+      oplog "reports incorrect answer #{args.answer} for", args.type, id, args.who, \
+          'callins'
       # cancel any matching entries on the call-in queue for this puzzle
       for c in CallIns.find(type: args.type, target: id, answer: args.answer).fetch()
         Meteor.call 'cancelCallIn',
@@ -1529,6 +1538,7 @@ share.model =
   pretty_collection: pretty_collection
   getTag: getTag
   canonical: canonical
+  oplog: oplog
   drive_id_to_link: drive_id_to_link
   spread_id_to_link: spread_id_to_link
   UTCNow: UTCNow

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -1431,7 +1431,7 @@ spread_id_to_link = (id) ->
         solved_by: canonical(args.who)
         touched: now
         touched_by: canonical(args.who)
-      oplog "Found an answer to", args.type, id, args.who, 'answers'
+      oplog "Found an answer (#{args.answer.toUpperCase()}) to", args.type, id, args.who, 'answers'
       # cancel any entries on the call-in queue for this puzzle
       for c in CallIns.find(type: args.type, target: id).fetch()
         Meteor.call 'cancelCallIn',

--- a/server/hubot-scripts/codex.coffee
+++ b/server/hubot-scripts/codex.coffee
@@ -14,6 +14,7 @@
 #   hubot bot: New quip: <quip>
 #   hubot bot: stuck [on <puzzle>] [because <reason>]
 #   hubot bot: unstuck [on <puzzle>]
+#   hubot bot: announce <message>
 
 # helper function: concat regexes
 rejoin = (regs...) ->
@@ -370,4 +371,10 @@ share.hubot.codex = (robot) ->
     if msg.envelope.room isnt "general/0" and \
        msg.envelope.room isnt "#{target.type}/#{target.object._id}"
       msg.reply new share.Useful, "Call for help cancelled"
+    msg.finish()
+
+  robot.commands.push 'bot announce <message>'
+  robot.respond /announce (.*)$/i, (msg) ->
+    share.model.oplog msg.match[1], "", "", msg.envelope.user.id, \
+        "announcements"
     msg.finish()


### PR DESCRIPTION
Oplog messages to which one might want to subscribe are given streams. Each stream can be separately subscribed to or unsubscribed from via an interface on the blackboard main page, which is persistent and reactive between tabs.