### PR TITLE
Puzzle tabs

### DIFF
--- a/blackboard.less
+++ b/blackboard.less
@@ -517,8 +517,6 @@ html.fullHeight {
        & > .bb-right-content {
          position: absolute;
          right: 0px;
-         width: 300px;
-         padding-bottom: 306px; /* for bottom pane */
          & > .bb-top-right-content, & > .bb-bottom-right-content {
            width: 100%;
            height: 100%;

--- a/blackboard.less
+++ b/blackboard.less
@@ -511,7 +511,12 @@ html.fullHeight {
          iframe {
            padding-top: 0px; /* was 26px, but we're chosing to overlap header */
            border-top: none;
+           &.bb-puzzle-frame { padding-top:5px; }
          }
+       }
+       table:not(.table-bordered) {
+         tr > td:first-child { text-align: right }
+         td.rightanswer, td.wronganswer { font-weight: bold }
        }
        /* horizontal splitter in right half */
        & > .bb-right-content {
@@ -521,12 +526,6 @@ html.fullHeight {
            width: 100%;
            height: 100%;
            overflow: auto;
-         }
-         & > .bb-top-right-content {
-           table:not(.table-bordered) {
-             tr > td:first-child { text-align: right }
-             td.rightanswer, td.wronganswer { font-weight: bold }
-           }
          }
          & > .bb-splitter-handle {
            height: 6px;
@@ -542,7 +541,7 @@ html.fullHeight {
          }
          & > .bb-bottom-right-content {
            position: absolute;
-           height: 300px; right: 0; bottom: 0;
+           right: 0; bottom: 0;
            /* chat stylin' */
            background: url('/img/grid_noise.png');
            background-attachment: fixed;
@@ -571,6 +570,9 @@ html.fullHeight {
              border: 1px solid #888;
              padding-left: 2px; padding-right: 4px;
              border-bottom-left-radius: 5px;
+             &.in-margin {
+               padding-top: 5px;
+             }
            }
          }
        }

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -472,7 +472,7 @@ tagHelper = (id) ->
 
 Template.blackboard_tags.helpers { tags: tagHelper }
 Template.blackboard_puzzle_tags.helpers { tags: tagHelper }
-Template.puzzle.helpers { tags: tagHelper }
+Template.puzzle_info.helpers { tags: tagHelper }
 
 # Subscribe to all group, round, and puzzle information
 Template.blackboard.onCreated -> this.autorun =>

--- a/client/header.coffee
+++ b/client/header.coffee
@@ -208,20 +208,23 @@ Template.header_breadcrumb_chat.helpers
     return false unless Session.equals 'type', @type
     Session.equals 'id', @id
 
+
+active = ->
+  (Session.equals('currentPage', @page) or Session.equals('currentPage', 'chat')) and \
+  Session.equals('type', @type) and Session.equals('id', @id)
+
 Template.header_breadcrumb_round.onCreated ->
   @autorun =>
     @subscribe 'round-by-id', Template.currentData().id
 Template.header_breadcrumb_round.helpers
-  round: ->
-    model.Rounds.findOne @id if @id
+  round: -> model.Rounds.findOne @id if @id
 
 Template.header_breadcrumb_puzzle.onCreated ->
   @autorun =>
     @subscribe 'puzzle-by-id', Template.currentData().id
     @subscribe 'round-for-puzzle', Template.currentData().id
 Template.header_breadcrumb_puzzle.helpers
-  puzzle: ->
-    model.Puzzles.findOne @id if @id
+  puzzle: -> model.Puzzles.findOne @id if @id
 
 Template.header_breadcrumb_quip.onCreated ->
   @autorun => @subscribe 'quips'
@@ -232,6 +235,7 @@ Template.header_breadcrumb_quip.helpers ->
 Template.header_breadcrumbs.helpers
   breadcrumbs: -> Session.get 'breadcrumbs'
   crumb_template: -> "header_breadcrumb_#{this.page}"
+  active: active
   round: ->
     if Session.equals('type', 'puzzles')
       model.Rounds.findOne puzzles: Session.get("id")

--- a/client/header.coffee
+++ b/client/header.coffee
@@ -208,16 +208,22 @@ Template.header_breadcrumb_chat.helpers
     return false unless Session.equals 'type', @type
     Session.equals 'id', @id
 
-
 active = ->
   (Session.equals('currentPage', @page) or Session.equals('currentPage', 'chat')) and \
   Session.equals('type', @type) and Session.equals('id', @id)
+
+Template.header_breadcrumb_blackboard.helpers
+  active: active
+
+Template.header_breadcrumb_extra_links.helpers
+  active: -> active.bind(Template.parentData(1))()
 
 Template.header_breadcrumb_round.onCreated ->
   @autorun =>
     @subscribe 'round-by-id', Template.currentData().id
 Template.header_breadcrumb_round.helpers
   round: -> model.Rounds.findOne @id if @id
+  active: active
 
 Template.header_breadcrumb_puzzle.onCreated ->
   @autorun =>
@@ -225,6 +231,7 @@ Template.header_breadcrumb_puzzle.onCreated ->
     @subscribe 'round-for-puzzle', Template.currentData().id
 Template.header_breadcrumb_puzzle.helpers
   puzzle: -> model.Puzzles.findOne @id if @id
+  active: active
 
 Template.header_breadcrumb_quip.onCreated ->
   @autorun => @subscribe 'quips'

--- a/client/main.coffee
+++ b/client/main.coffee
@@ -143,7 +143,9 @@ BlackboardRouter = Backbone.Router.extend
     "": "BlackboardPage"
     "edit": "EditPage"
     "rounds/:round": "RoundPage"
+    "rounds/:round/:view": "RoundPage"
     "puzzles/:puzzle": "PuzzlePage"
+    "puzzles/:puzzle/:view": "PuzzlePage"
     "roundgroups/:roundgroup": "RoundGroupPage"
     "chat/:type/:id": "ChatPage"
     "chat/:type/:id/:timestamp": "ChatPage"
@@ -165,13 +167,17 @@ BlackboardRouter = Backbone.Router.extend
       canEdit: true
       editing: undefined
 
-  RoundPage: (id) ->
+  RoundPage: (id, view=null) ->
     this.Page("round", "rounds", id)
-    Session.set "timestamp", 0
+    Session.set
+      timestamp: 0
+      view: view
 
-  PuzzlePage: (id) ->
+  PuzzlePage: (id, view=null) ->
     this.Page("puzzle", "puzzles", id)
-    Session.set "timestamp", 0
+    Session.set
+      timestamp: 0
+      view: view
 
   RoundGroupPage: (id) ->
     this.goToChat "roundgroups", id, 0

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -8,23 +8,21 @@ capType = (type) ->
   else if type is 'rounds'
     'Round'
 
-defaultView = (puzzle) ->
-  return 'spreadsheet' if puzzle?.spreadsheet?
-  return 'puzzle' if puzzle?.link?
-  return 'info'
+possibleViews = (puzzle) ->
+  x = []
+  x.push 'spreadsheet' if puzzle?.spreadsheet?
+  x.push 'puzzle' if puzzle?.link?
+  x.push 'info'
+  x
 currentViewIs = (puzzle, view) ->
   # only puzzle and round have view.
   page = Session.get 'currentPage'
   return false unless (page is 'puzzle') or (page is 'round')
+  possible = possibleViews puzzle
   if Session.equals 'view', view
-    switch view
-      when 'spreadsheet'
-        return true if puzzle?.spreadsheet?
-      when 'puzzle'
-        return true if puzzle?.link?
-      when 'info'
-        return true
-  return view is defaultView puzzle
+    return true if possible.includes view
+  return false if possible.includes Session.get 'view'
+  return view is possible[0]
 
 Template.puzzle_info.helpers
    tag: (name) -> (model.getTag this, name) or ''

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -8,6 +8,23 @@ capType = (type) ->
   else if type is 'rounds'
     'Round'
 
+defaultView = (puzzle) ->
+  return 'spreadsheet' if puzzle.spreadsheet?
+  return 'puzzle' if puzzle.link?
+  return 'info'
+currentViewIs = (puzzle, view) ->
+  if Session.equals 'view', view
+    switch view
+      when 'spreadsheet'
+        return puzzle.spreadsheet?
+      when 'puzzle'
+        return puzzle.link?
+      when 'info'
+        return true
+  if not Session.get('view')?
+    return view is defaultView puzzle
+  return false
+
 Template.puzzle.helpers
   tag: (name) -> (model.getTag this, name) or ''
   data: ->
@@ -30,6 +47,10 @@ Template.puzzle.helpers
   vsize: -> share.Splitter.vsize.get()
   vsizePlusHandle: -> +share.Splitter.vsize.get() + 6
   hsize: -> share.Splitter.hsize.get()
+  currentViewIs: (view) -> currentViewIs @puzzle, view
+
+Template.header_breadcrumb_extra_links.helpers
+  currentViewIs: (view) -> currentViewIs @puzzle, view
 
 Template.puzzle.onCreated ->
   $('html').addClass('fullHeight')

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -9,24 +9,29 @@ capType = (type) ->
     'Round'
 
 defaultView = (puzzle) ->
-  return 'spreadsheet' if puzzle.spreadsheet?
-  return 'puzzle' if puzzle.link?
+  return 'spreadsheet' if puzzle?.spreadsheet?
+  return 'puzzle' if puzzle?.link?
   return 'info'
 currentViewIs = (puzzle, view) ->
+  # only puzzle and round have view.
+  page = Session.get 'currentPage'
+  return false unless (page is 'puzzle') or (page is 'round')
   if Session.equals 'view', view
     switch view
       when 'spreadsheet'
-        return puzzle.spreadsheet?
+        return puzzle?.spreadsheet?
       when 'puzzle'
-        return puzzle.link?
+        return puzzle?.link?
       when 'info'
         return true
   if not Session.get('view')?
     return view is defaultView puzzle
   return false
 
+Template.puzzle_info.helpers
+   tag: (name) -> (model.getTag this, name) or ''
+
 Template.puzzle.helpers
-  tag: (name) -> (model.getTag this, name) or ''
   data: ->
     r = {}
     r.type = Session.get('type')
@@ -50,7 +55,7 @@ Template.puzzle.helpers
   currentViewIs: (view) -> currentViewIs @puzzle, view
 
 Template.header_breadcrumb_extra_links.helpers
-  currentViewIs: (view) -> currentViewIs @puzzle, view
+  currentViewIs: (view) -> currentViewIs this, view
 
 Template.puzzle.onCreated ->
   $('html').addClass('fullHeight')

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -19,14 +19,12 @@ currentViewIs = (puzzle, view) ->
   if Session.equals 'view', view
     switch view
       when 'spreadsheet'
-        return puzzle?.spreadsheet?
+        return true if puzzle?.spreadsheet?
       when 'puzzle'
-        return puzzle?.link?
+        return true if puzzle?.link?
       when 'info'
         return true
-  if not Session.get('view')?
-    return view is defaultView puzzle
-  return false
+  return view is defaultView puzzle
 
 Template.puzzle_info.helpers
    tag: (name) -> (model.getTag this, name) or ''

--- a/header.html
+++ b/header.html
@@ -13,29 +13,31 @@
 </template>
 
 <template name="header_breadcrumb_chat">
-  <li class="{{#if inThisRoom}}active{{/if}}">
-    <a href="/chat/{{type}}/{{id}}" class="chat-link"><i class="icon-comment icon-white"></i> {{> Template.contentBlock}} Chat</a>
-  </li>
+  <a class="{{#if inThisRoom}}current{{/if}}" href="/chat/{{type}}/{{id}}" class="chat-link"><i class="icon-comment icon-white"></i></a>
 </template>
 
 <template name="header_breadcrumb_blackboard">
   <li class="{{#if currentPageEquals "blackboard"}}active{{/if}}">
     <a href="/" class="home-link"><i class="icon-home icon-white"></i> Blackboard</a>
+    {{> header_breadcrumb_chat}}
   </li>
-  {{> header_breadcrumb_chat}}
 </template>
 
 <template name="header_breadcrumb_extra_links">
-  {{#if this.link}}
-    <a href="{{this.link}}" target="_blank" title="Round on hunt site">
-      <i class="icon-share-alt icon-white"></i>
+  {{#if puzzle.link}}
+    <a class="{{#if active}}{{#if currentViewIs "puzzle"}}current{{/if}}{{/if}}" href="/{{../type}}/{{../id}}/puzzle" title="Puzzle">
+      <i class="icon-globe icon-white"></i>
     </a>
   {{/if}}
-  {{#if spreadsheet}}
-    <a href="{{spread_link spreadsheet}}" target="_blank" title="Spreadsheet">
+  {{#if puzzle.spreadsheet}}
+    <a class="{{#if active}}{{#if currentViewIs "spreadsheet"}}current{{/if}}{{/if}}" href="/{{../type}}/{{../id}}/spreadsheet" title="Spreadsheet">
       <i class="icon-th icon-white"></i>
     </a>
   {{/if}}
+    <a class="{{#if active}}{{#if currentViewIs "info"}}current{{/if}}{{/if}}" href="/{{../type}}/{{../id}}/info"  title="Info">
+      <i class="icon-tasks icon-white"></i>
+    </a>
+  {{> header_breadcrumb_chat ..}}
 </template>
 
 <template name="header_breadcrumb_round">
@@ -43,9 +45,8 @@
     <a href="/rounds/{{id}}" class="rounds-link">
       <i class="icon-folder-open icon-white"></i> Round: {{round.name}}
     </a>
-    {{> header_breadcrumb_extra_links round}}
+    {{> header_breadcrumb_extra_links puzzle=round active=(currentPageEquals "round")}}
   </li>
-  {{> header_breadcrumb_chat }}
 </template>
 
 <template name="header_breadcrumb_puzzle">
@@ -53,9 +54,8 @@
     <a href="/puzzles/{{id}}" class="puzzles-link">
       <i class="icon-book icon-white"></i> Puzzle: {{puzzle.name}}
     </a>
-    {{> header_breadcrumb_extra_links puzzle}}
+    {{> header_breadcrumb_extra_links puzzle=puzzle active=(currentPageEquals "puzzle")}}
   </li>
-  {{> header_breadcrumb_chat }}
 </template>
 
 <template name="header_breadcrumb_quip">

--- a/header.html
+++ b/header.html
@@ -13,48 +13,49 @@
 </template>
 
 <template name="header_breadcrumb_chat">
-  <a class="{{#if inThisRoom}}current{{/if}}" href="/chat/{{type}}/{{id}}" class="chat-link"><i class="icon-comment icon-white"></i></a>
+  <a href="/chat/{{type}}/{{id}}" class="chat-link{{#if inThisRoom}} current{{/if}}" title="Chat"><i class="icon-comment icon-white"></i></a>
 </template>
 
 <template name="header_breadcrumb_blackboard">
-  <li class="{{#if currentPageEquals "blackboard"}}active{{/if}}">
-    <a href="/" class="home-link"><i class="icon-home icon-white"></i> Blackboard</a>
+  <li class="{{#if active}}active{{/if}}">
+    <a href="/" class="home-link"><i class="icon-home icon-white"></i> Blackboard
+    <i class="icon-th-list icon-white {{#if currentPageEquals "blackboard"}}current{{/if}}"></i></a>
     {{> header_breadcrumb_chat}}
   </li>
 </template>
 
 <template name="header_breadcrumb_extra_links">
-  {{#if puzzle.link}}
-    <a class="{{#if active}}{{#if currentViewIs "puzzle"}}current{{/if}}{{/if}}" href="/{{../type}}/{{../id}}/puzzle" title="Puzzle">
+  {{#if this.link}}
+    <a class="{{../type}}-link {{#if active}}{{#if currentViewIs "puzzle"}}current{{/if}}{{/if}}" href="/{{../type}}/{{../id}}/puzzle" title="Puzzle">
       <i class="icon-globe icon-white"></i>
     </a>
   {{/if}}
-  {{#if puzzle.spreadsheet}}
-    <a class="{{#if active}}{{#if currentViewIs "spreadsheet"}}current{{/if}}{{/if}}" href="/{{../type}}/{{../id}}/spreadsheet" title="Spreadsheet">
+  {{#if spreadsheet}}
+    <a class="{{../type}}-link {{#if active}}{{#if currentViewIs "spreadsheet"}}current{{/if}}{{/if}}" href="/{{../type}}/{{../id}}/spreadsheet" title="Spreadsheet">
       <i class="icon-th icon-white"></i>
     </a>
   {{/if}}
-    <a class="{{#if active}}{{#if currentViewIs "info"}}current{{/if}}{{/if}}" href="/{{../type}}/{{../id}}/info"  title="Info">
-      <i class="icon-tasks icon-white"></i>
+    <a class="{{../type}}-link {{#if active}}{{#if currentViewIs "info"}}current{{/if}}{{/if}}" href="/{{../type}}/{{../id}}/info"  title="Info">
+      <i class="icon-info-sign icon-white"></i>
     </a>
   {{> header_breadcrumb_chat ..}}
 </template>
 
 <template name="header_breadcrumb_round">
-  <li class="{{#if currentPageEquals "round"}}active{{else}}bb-omit-when-narrow{{/if}}">
+  <li class="{{#if active}}active{{else}}bb-omit-when-narrow{{/if}}">
     <a href="/rounds/{{id}}" class="rounds-link">
       <i class="icon-folder-open icon-white"></i> Round: {{round.name}}
     </a>
-    {{> header_breadcrumb_extra_links puzzle=round active=(currentPageEquals "round")}}
+    {{> header_breadcrumb_extra_links round}}
   </li>
 </template>
 
 <template name="header_breadcrumb_puzzle">
-  <li class="{{#if currentPageEquals "puzzle"}}active{{else}}bb-omit-when-narrow{{/if}}">
+  <li class="{{#if active}}active{{else}}bb-omit-when-narrow{{/if}}">
     <a href="/puzzles/{{id}}" class="puzzles-link">
       <i class="icon-book icon-white"></i> Puzzle: {{puzzle.name}}
     </a>
-    {{> header_breadcrumb_extra_links puzzle=puzzle active=(currentPageEquals "puzzle")}}
+    {{> header_breadcrumb_extra_links puzzle}}
   </li>
 </template>
 

--- a/header.less
+++ b/header.less
@@ -21,6 +21,12 @@
           padding-left: 0px;
           margin-left: -10px;
         }
+        i.current, .current i {
+          border-bottom: 2px solid white;
+        }
+        a:not(.current) i:not(.current):hover {
+          border-bottom: 1px solid white;
+        }
       }
       & > .fill {
         flex-grow: 1;

--- a/puzzle.html
+++ b/puzzle.html
@@ -38,7 +38,7 @@
 <div class="bb-splitter" style="padding-right: {{hsize}}px">
   <div class="bb-left-content">{{! start left of splitter }}
   {{#if puzzle.spreadsheet}}
-    <div class="bb-left-header">
+    <div class="bb-left-header" style="{{#unless currentViewIs "spreadsheet"}}display: none;{{/unless}}">
       <a align="center" href="{{spread_link puzzle.spreadsheet}}"
          target="_blank"><i class='icon-fullscreen'></i>
       Open spreadsheet in new window</a>
@@ -48,21 +48,21 @@
             style="{{#unless currentViewIs "spreadsheet"}}display:none{{/unless}}"></iframe>
   {{/if}}
   {{#if puzzle.link}}
-    <div class="bb-left-header">
+    <div class="bb-left-header" style="{{#unless currentViewIs "puzzle"}}display: none;{{/unless}}">
       <a align="center" href="{{puzzle.link}}"
          target="_blank"><i class='icon-fullscreen'></i>
       Open puzzle in new window</a>
     </div>
     {{! hide iframe when not current view for faster tab change }}
-    <iframe class="bb-spreadsheet-frame" frameborder='0' src='{{puzzle.link}}'
+    <iframe class="bb-puzzle-frame" frameborder='0' src='{{puzzle.link}}'
             style="{{#unless currentViewIs "puzzle"}}display:none{{/unless}}"></iframe>
   {{/if}}
   {{#if currentViewIs "info"}}
-    <div class="bb-spreadsheet-frame">{{> puzzle_info}}</div>
+    <div class="bb-puzzle-frame">{{> puzzle_info}}</div>
   {{/if}}
   </div>{{! end left of splitter }}
   <div class="bb-splitter-handle" style="right: {{hsize}}px"></div>
-  <div class="bb-right-content" style="{{#unless currentViewIs "info"}}width: {{hsize}}px; padding-bottom: {{vsizePlusHandle}}px{{/unless}}">{{! start right of splitter }}
+  <div class="bb-right-content" style="width: {{hsize}}px; {{#unless currentViewIs "info"}}padding-bottom: {{vsizePlusHandle}}px{{/unless}}">{{! start right of splitter }}
     {{#unless currentViewIs "info"}}
     <div class="bb-top-right-content">{{! start top right splitter }}
       {{> puzzle_info }}
@@ -76,7 +76,7 @@
       <div class="bb-chat-input bb-chat-footer">
         {{> messages_input }}
       </div>
-      <div class="bb-chat-pop-out">
+      <div class="bb-chat-pop-out {{#if currentViewIs "info"}}in-margin{{/if}}">
         <a href="/chat/{{type}}/{{puzzle._id}}" class="chat-link bb-pop-out"
            target="chat{{puzzle._id}}"><i class="icon-share-alt"></i>
       Pop out</a>

--- a/puzzle.html
+++ b/puzzle.html
@@ -1,3 +1,36 @@
+<template name="puzzle_info">
+<div class="{{#if stuck}}bb-status-stuck{{else if puzzle.solved}}bb-status-solved{{/if}}">
+  <h1>{{puzzle.name}}</h1>
+  <h2>{{capType}}
+    {{#if puzzle.link}}(<a href="{{puzzle.link}}" target="_blank">link<i class="icon-share-alt"></i></a>){{/if}}
+  </h2>
+</div>
+{{#with puzzle}}
+  <table><tbody>
+  {{#if solved}}
+    <tr><td class="rightanswer">Answer:</td><td class="answer">{{tag "answer"}}</td></tr>
+    <tr><td class="backsolve">{{#if tag "backsolved"}}(backsolved){{/if}}</td><td class="timestamp">{{pretty_ts solved}}</td></tr>
+  {{/if}}
+  {{#each incorrectAnswers}}
+    <tr><td class="wronganswer">IncorrectAnswer:</td><td class="answer">{{answer}}</td></tr>
+    <tr><td class="backsolve">{{#if backsolve}}(backsolved){{/if}}</td><td class="timestamp">{{pretty_ts timestamp}}</td></tr>
+  {{/each}}
+  {{#each tags _id}}
+    <tr><td class="tagname">{{name}}:</td><td class="tagvalue">{{value}}</td></tr>
+  {{/each}}
+  </tbody></table>
+{{/with}}
+{{> starred_messages canModify=mynick}}
+{{#if puzzles}}
+<table class="bb-round-answers table table-bordered table-condensed"><tbody>
+  <tr><th>Puzzle in round</th><th>Answer</th></tr>
+  {{#each puzzles}}
+  <tr><td>{{link _id}}</td><td class="answer">{{#if solved}}{{tag "answer"}}{{/if}}</td></tr>
+  {{/each}}
+</tbody></table>
+{{/if}}
+</template>
+
 <template name="puzzle">
 <div class="row-fluid bb-puzzleround">
  <!-- this is a puzzle page -->
@@ -10,47 +43,33 @@
          target="_blank"><i class='icon-fullscreen'></i>
       Open spreadsheet in new window</a>
     </div>
-    <iframe class="bb-spreadsheet-frame" frameborder='0' src='{{spread_link puzzle.spreadsheet}}&widget=true&chrome=false'></iframe>
-  {{else}}
-    <p>No spreadsheet.</p>
+    {{! hide iframe when not current view for faster tab change }}
+    <iframe class="bb-spreadsheet-frame" frameborder='0' src='{{spread_link puzzle.spreadsheet}}&widget=true&chrome=false'
+            style="{{#unless currentViewIs "spreadsheet"}}display:none{{/unless}}"></iframe>
+  {{/if}}
+  {{#if puzzle.link}}
+    <div class="bb-left-header">
+      <a align="center" href="{{puzzle.link}}"
+         target="_blank"><i class='icon-fullscreen'></i>
+      Open puzzle in new window</a>
+    </div>
+    {{! hide iframe when not current view for faster tab change }}
+    <iframe class="bb-spreadsheet-frame" frameborder='0' src='{{puzzle.link}}'
+            style="{{#unless currentViewIs "puzzle"}}display:none{{/unless}}"></iframe>
+  {{/if}}
+  {{#if currentViewIs "info"}}
+    <div class="bb-spreadsheet-frame">{{> puzzle_info}}</div>
   {{/if}}
   </div>{{! end left of splitter }}
   <div class="bb-splitter-handle" style="right: {{hsize}}px"></div>
-  <div class="bb-right-content" style="width: {{hsize}}px; padding-bottom: {{vsizePlusHandle}}px">{{! start right of splitter }}
+  <div class="bb-right-content" style="{{#unless currentViewIs "info"}}width: {{hsize}}px; padding-bottom: {{vsizePlusHandle}}px{{/unless}}">{{! start right of splitter }}
+    {{#unless currentViewIs "info"}}
     <div class="bb-top-right-content">{{! start top right splitter }}
-      <div class="{{#if stuck}}bb-status-stuck{{else if puzzle.solved}}bb-status-solved{{/if}}">
-        <h1>{{puzzle.name}}</h1>
-        <h2>{{capType}}
-          {{#if puzzle.link}}(<a href="{{puzzle.link}}" target="_blank">link<i class="icon-share-alt"></i></a>){{/if}}
-        </h2>
-      </div>
-      {{#with puzzle}}
-        <table><tbody>
-        {{#if solved}}
-          <tr><td class="rightanswer">Answer:</td><td class="answer">{{tag "answer"}}</td></tr>
-          <tr><td class="backsolve">{{#if tag "backsolved"}}(backsolved){{/if}}</td><td class="timestamp">{{pretty_ts solved}}</td></tr>
-        {{/if}}
-        {{#each incorrectAnswers}}
-          <tr><td class="wronganswer">IncorrectAnswer:</td><td class="answer">{{answer}}</td></tr>
-          <tr><td class="backsolve">{{#if backsolve}}(backsolved){{/if}}</td><td class="timestamp">{{pretty_ts timestamp}}</td></tr>
-        {{/each}}
-        {{#each tags _id}}
-          <tr><td class="tagname">{{name}}:</td><td class="tagvalue">{{value}}</td></tr>
-        {{/each}}
-        </tbody></table>
-      {{/with}}
-      {{> starred_messages canModify=mynick}}
-      {{#if puzzles}}
-      <table class="bb-round-answers table table-bordered table-condensed"><tbody>
-        <tr><th>Puzzle in round</th><th>Answer</th></tr>
-        {{#each puzzles}}
-        <tr><td>{{link _id}}</td><td class="answer">{{#if solved}}{{tag "answer"}}{{/if}}</td></tr>
-        {{/each}}
-      </tbody></table>
-      {{/if}}
+      {{> puzzle_info }}
     </div>
     <div class="bb-splitter-handle" style="bottom: {{vsize}}px"></div>
-    <div class="bb-bottom-right-content" style="height: {{vsize}}px">{{! start bottom right splitter }}
+    {{/unless}}
+    <div class="bb-bottom-right-content" style="{{#unless currentViewIs "info"}}height: {{vsize}}px{{/unless}}">{{! start bottom right splitter }}
       <div class="bb-message-container">
         {{> messages }}
       </div>


### PR DESCRIPTION
Icons in breadcrumbs behave as tabs, changing what displays in the spreadsheet area of the three-pane view.
Fixes cjb/codex-blackboard#322.
Covers some of what cjb/codex-blackboard#93 and cjb/codex-blackboard#131 were asking for.