### PR TITLE
Use embedded object for tags instead of array

### DIFF
--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -461,14 +461,17 @@ Template.blackboard_round.events
 
 tagHelper = (id) ->
   isRoundGroup = ('rounds' of this)
-  { id: id, name: t.name, canon: t.canon, value: t.value } \
-    for t in (this?.tags or []) when not \
-        ((Session.equals('currentPage', 'blackboard') and \
-         (t.canon is 'status' or \
-             (!isRoundGroup and t.canon is 'answer'))) or \
-         ((t.canon is 'answer' or t.canon is 'backsolve') and \
-          (Session.equals('currentPage', 'puzzle') or \
-           Session.equals('currentPage', 'round'))))
+  tags = this?.tags or {}
+  (
+    t = tags[canon]
+    { id, name: t.name, canon, value: t.value }
+  ) for canon in Object.keys(tags).sort() when not \
+    ((Session.equals('currentPage', 'blackboard') and \
+      (canon is 'status' or \
+          (!isRoundGroup and canon is 'answer'))) or \
+      ((canon is 'answer' or canon is 'backsolve') and \
+      (Session.equals('currentPage', 'puzzle') or \
+        Session.equals('currentPage', 'round'))))
 
 Template.blackboard_tags.helpers { tags: tagHelper }
 Template.blackboard_puzzle_tags.helpers { tags: tagHelper }

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -299,15 +299,13 @@ processBlackboardEdit =
     n = model.Names.findOne(id)
     if text is null # delete tag
       return Meteor.call 'deleteTag', {type:n.type, object:id, name:canon, who:who}
-    tags = model.collection(n.type).findOne(id).tags
-    t = (tag for tag in tags when tag.canon is canon)[0]
+    t = model.collection(n.type).findOne(id).tags[canon]
     Meteor.call 'setTag', {type:n.type, object:id, name:text, value:t.value, who:who}, (error,result) ->
-      if (t.canon isnt model.canonical(text)) and (not error)
+      if (canon isnt model.canonical(text)) and (not error)
         Meteor.call 'deleteTag', {type:n.type, object:id, name:t.name, who:who}
   tags_value: (text, id, canon) ->
     n = model.Names.findOne(id)
-    tags = model.collection(n.type).findOne(id).tags
-    t = (tag for tag in tags when tag.canon is canon)[0]
+    t = model.collection(n.type).findOne(id).tags[canon]
     # special case for 'status' tag, which might not previously exist
     for special in ['Status', 'Answer']
       if (not t) and canon is model.canonical(special)

--- a/lib/imports/tags.coffee
+++ b/lib/imports/tags.coffee
@@ -3,8 +3,7 @@
 import canonical from './canonical.coffee'
 import { ObjectWith, NonEmptyString } from './match.coffee'
 
-export getTag = (object, name) ->
-  (tag.value for tag in (object?.tags or []) when tag.canon is canonical(name))[0]
+export getTag = (object, name) -> object?.tags?[canonical(name)]?.value
 
 export isStuck = (object) ->
   object? and /^stuck\b/i.test(getTag(object, 'Status') or '')
@@ -12,10 +11,11 @@ export isStuck = (object) ->
 export canonicalTags = (tags, who) ->
   check tags, [ObjectWith(name:NonEmptyString,value:Match.Any)]
   now = Date.now()
-  ({
+  result = {}
+  (result[canonical(tag.name)] =
     name: tag.name
-    canon: canonical(tag.name)
     value: tag.value
     touched: tag.touched ? now
     touched_by: tag.touched_by ? canonical(who)
-  } for tag in tags)
+  ) for tag in tags
+  result

--- a/lib/imports/tags.test.coffee
+++ b/lib/imports/tags.test.coffee
@@ -9,16 +9,16 @@ describe 'getTag', ->
     chai.assert.isUndefined tags.getTag {}, 'foo'
 
   it 'accepts empty tags', ->
-    chai.assert.isUndefined tags.getTag {tags: []}, 'foo'
+    chai.assert.isUndefined tags.getTag {tags: {}}, 'foo'
 
   it 'accepts nonmatching tags', ->
-    chai.assert.isUndefined tags.getTag {tags: [{name: 'Yo', canon: 'yo', value: 'ho ho'}]}, 'foo'
+    chai.assert.isUndefined tags.getTag {tags: yo: {name: 'Yo', value: 'ho ho'}}, 'foo'
 
   it 'accepts matching tags', ->
-    chai.assert.equal tags.getTag({tags: [{name: 'Yo', canon: 'yo', value: 'ho ho'}]}, 'yo'), 'ho ho'
+    chai.assert.equal tags.getTag({tags: yo: {name: 'Yo', canon: 'yo', value: 'ho ho'}}, 'yo'), 'ho ho'
 
   it 'canonicalizes tags', ->
-    chai.assert.equal tags.getTag({tags: [{name: 'Yo', canon: 'yo', value: 'ho ho'}]}, 'yO'), 'ho ho'
+    chai.assert.equal tags.getTag({tags: yo: {name: 'Yo', canon: 'yo', value: 'ho ho'}}, 'yO'), 'ho ho'
 
 describe 'isStuck', ->
   it 'accepts missing object', ->
@@ -28,42 +28,36 @@ describe 'isStuck', ->
     chai.assert.isFalse tags.isStuck {}
 
   it 'accepts empty tags', ->
-    chai.assert.isFalse tags.isStuck {tags: []}
+    chai.assert.isFalse tags.isStuck {tags: {}}
 
   it 'ignores other tags', ->
-    chai.assert.isFalse tags.isStuck {tags: [{name: 'Yo', canon: 'yo', value: 'ho ho'}]}
+    chai.assert.isFalse tags.isStuck {tags: yo: {name: 'Yo', canon: 'yo', value: 'ho ho'}}
 
   it 'ignores nonstuck status', ->
-    chai.assert.isFalse tags.isStuck {tags: [{name: 'Status', canon: 'status', value: 'making progress'}]}
+    chai.assert.isFalse tags.isStuck {tags: status: {name: 'Status', value: 'making progress'}}
 
   it 'matches stuck status', ->
-    chai.assert.isTrue tags.isStuck {tags: [{name: 'Status', canon: 'status', value: 'stuck'}]}
+    chai.assert.isTrue tags.isStuck {tags: status: {name: 'Status', value: 'stuck'}}
 
   it 'matches verbose stuck status', ->
-    chai.assert.isTrue tags.isStuck {tags: [{name: 'Status', canon: 'status', value: 'Stuck to the wall'}]}
+    chai.assert.isTrue tags.isStuck {tags: status: {name: 'Status', value: 'Stuck to the wall'}}
 
 describe 'canonicalTags', ->
-  it 'requires list', ->
-    chai.assert.throws ->
-      tags.canonicalTags null, 'torgen'
-    chai.assert.throws ->
-      tags.canonicalTags {}, 'torgen'
-    chai.assert.deepEqual tags.canonicalTags([], 'torgen'), []
 
   it 'fills entries', ->
     pre = Date.now()
-    [foo, baz] = tags.canonicalTags [{name: 'Foo', value: 'bar'}, {name: 'BaZ', value: 'qux'}], 'Torgen'
-    chai.assert.include foo, {name: 'Foo', canon: 'foo', value: 'bar', touched_by: 'torgen'}
+    {foo, baz} = tags.canonicalTags [{name: 'Foo', value: 'bar'}, {name: 'BaZ', value: 'qux'}], 'Torgen'
+    chai.assert.include foo, {name: 'Foo', value: 'bar', touched_by: 'torgen'}
     chai.assert.isAtLeast foo.touched, pre
-    chai.assert.include baz, {name: 'BaZ', canon: 'baz', value: 'qux', touched_by: 'torgen'}
+    chai.assert.include baz, {name: 'BaZ', value: 'qux', touched_by: 'torgen'}
     chai.assert.isAtLeast baz.touched, pre
 
   it 'preserves touched', ->
     pre = Date.now() - 5
     chai.assert.deepEqual(
       tags.canonicalTags([{name: 'Foo', value: 'bar', touched: pre}], 'torgen'),
-      [{name: 'Foo', canon: 'foo', value: 'bar', touched: pre, touched_by: 'torgen'}])
+      foo: {name: 'Foo', value: 'bar', touched: pre, touched_by: 'torgen'})
 
   it 'preserves touched_by', ->
-    [tag] = tags.canonicalTags [{name: 'Foo', value: 'bar', touched_by: 'cscott'}], 'torgen'
-    chai.assert.include tag, {name: 'Foo', canon: 'foo', value: 'bar',  touched_by: 'cscott'}
+    {foo} = tags.canonicalTags [{name: 'Foo', value: 'bar', touched_by: 'cscott'}], 'torgen'
+    chai.assert.include foo, {name: 'Foo', value: 'bar',  touched_by: 'cscott'}

--- a/lib/methods/addIncorrectAnswer.test.coffee
+++ b/lib/methods/addIncorrectAnswer.test.coffee
@@ -24,7 +24,7 @@ describe 'addIncorrectAnswer', ->
     id = model.Nicks.insert
       name: 'Torgen'
       canon: 'torgen'
-      tags: [{name: 'Answer', canon: 'answer', value: 'knock knock', touched: 1, touched_by: 'torgen'}]
+      tags: answer: {name: 'Answer', value: 'knock knock', touched: 1, touched_by: 'torgen'}
     chai.assert.throws ->
       Meteor.call 'addIncorrectAnswer',
         type: 'nicks'
@@ -56,7 +56,7 @@ describe 'addIncorrectAnswer', ->
             touched_by: 'torgen'
             solved: null
             solved_by: null
-            tags: [{name: 'Status', canon: 'status', value: 'stuck', touched: 2, touched_by: 'torgen'}]
+            tags: status: {name: 'Status', value: 'stuck', touched: 2, touched_by: 'torgen'}
             incorrectAnswers: [{answer: 'qux', who: 'torgen', timestamp: 2, backsolve: false, provided: false}]
           model.CallIns.insert
             type: type

--- a/lib/methods/cancelCallIn.test.coffee
+++ b/lib/methods/cancelCallIn.test.coffee
@@ -34,7 +34,7 @@ describe 'cancelCallIn', ->
           touched_by: 'cscott'
           solved: null
           solved_by: null
-          tags: []
+          tags: {}
         callin = model.CallIns.insert
           name: 'Foo:precipitate'
           type: type

--- a/lib/methods/correctCallIn.test.coffee
+++ b/lib/methods/correctCallIn.test.coffee
@@ -34,7 +34,7 @@ describe 'correctCallIn', ->
           touched_by: 'cscott'
           solved: null
           solved_by: null
-          tags: []
+          tags: {}
         callin = model.CallIns.insert
           name: 'Foo:precipitate'
           type: type
@@ -51,18 +51,16 @@ describe 'correctCallIn', ->
 
       it "updates #{model.pretty_collection(type)}", ->
         doc = model.collection(type).findOne puzzle
-        chai.assert.include doc,
+        chai.assert.deepInclude doc,
           touched: 7
           touched_by: 'cjb'
           solved: 7
           solved_by: 'cjb'
-        chai.assert.lengthOf doc.tags, 1
-        chai.assert.deepInclude doc.tags[0],
-          name: 'Answer'
-          canon: 'answer'
-          value: 'precipitate'
-          touched: 7
-          touched_by: 'cjb'
+          tags: answer:
+            name: 'Answer'
+            value: 'precipitate'
+            touched: 7
+            touched_by: 'cjb'
       
       it 'removes callin', ->
         chai.assert.isUndefined model.CallIns.findOne callin
@@ -105,7 +103,7 @@ describe 'correctCallIn', ->
       touched_by: 'cscott'
       solved: null
       solved_by: null
-      tags: []
+      tags: {}
       incorrectAnswers: []
     r = model.Rounds.insert
       name: 'Bar'
@@ -117,7 +115,7 @@ describe 'correctCallIn', ->
       solved: null
       solved_by: null
       puzzles: [p]
-      tags: []
+      tags: {}
       incorrectAnswers: []
     callin = model.CallIns.insert
       name: 'Foo:precipitate'

--- a/lib/methods/deleteAnswer.test.coffee
+++ b/lib/methods/deleteAnswer.test.coffee
@@ -24,7 +24,7 @@ describe 'deleteAnswer', ->
     id = model.Nicks.insert
       name: 'Torgen'
       canon: 'torgen'
-      tags: [{name: 'Answer', canon: 'answer', value: 'knock knock', touched: 1, touched_by: 'torgen'}]
+      tags: answer: {name: 'Answer',value: 'knock knock', touched: 1, touched_by: 'torgen'}
     chai.assert.throws ->
       Meteor.call 'deleteAnswer',
         type: 'nicks'
@@ -44,7 +44,7 @@ describe 'deleteAnswer', ->
           touched_by: 'torgen'
           solved: null
           solved_by: null
-          tags: [{name: 'Status', canon: 'status', value: 'stuck', touched: 2, touched_by: 'torgen'}]
+          tags: status: {name: 'Status', value: 'stuck', touched: 2, touched_by: 'torgen'}
         Meteor.call 'deleteAnswer',
           type: type
           target: id,
@@ -60,7 +60,7 @@ describe 'deleteAnswer', ->
           touched_by: 'cjb'
           solved: null
           solved_by: null
-          tags: [{name: 'Status', canon: 'status', value: 'stuck', touched: 2, touched_by: 'torgen'}]
+          tags: status: {name: 'Status', value: 'stuck', touched: 2, touched_by: 'torgen'}
         oplogs = model.Messages.find(room_name: 'oplog/0').fetch()
         chai.assert.equal oplogs.length, 1
         chai.assert.include oplogs[0],
@@ -87,8 +87,9 @@ describe 'deleteAnswer', ->
           touched_by: 'torgen'
           solved: 2
           solved_by: 'torgen'
-          tags: [{name: 'Answer', canon: 'answer', value: 'foo', touched: 2, touched_by: 'torgen'},
-                {name: 'Temperature', canon: 'temperature', value: '12', touched: 2, touched_by: 'torgen'}]
+          tags:
+            answer: {name: 'Answer', value: 'foo', touched: 2, touched_by: 'torgen'}
+            temperature: {name: 'Temperature', value: '12', touched: 2, touched_by: 'torgen'}
         Meteor.call 'deleteAnswer',
           type: type
           target: id,
@@ -104,7 +105,7 @@ describe 'deleteAnswer', ->
           touched_by: 'cjb'
           solved: null
           solved_by: null
-          tags: [{name: 'Temperature', canon: 'temperature', value: '12', touched: 2, touched_by: 'torgen'}]
+          tags: temperature: {name: 'Temperature', value: '12', touched: 2, touched_by: 'torgen'}
         oplogs = model.Messages.find(room_name: 'oplog/0').fetch()
         chai.assert.equal oplogs.length, 1
         chai.assert.include oplogs[0],
@@ -131,9 +132,10 @@ describe 'deleteAnswer', ->
           touched_by: 'torgen'
           solved: 2
           solved_by: 'torgen'
-          tags: [{name: 'Answer', canon: 'answer', value: 'foo', touched: 2, touched_by: 'torgen'},
-                {name: 'Backsolve', canon: 'backsolve', value: 'yes', touched: 2, touched_by: 'torgen'},
-                {name: 'Provided', canon: 'provided', value: 'yes', touched: 2, touched_by: 'torgen'}]
+          tags:
+            answer: {name: 'Answer', value: 'foo', touched: 2, touched_by: 'torgen'}
+            backsolve: {name: 'Backsolve', value: 'yes', touched: 2, touched_by: 'torgen'}
+            provided: {name: 'Provided', value: 'yes', touched: 2, touched_by: 'torgen'}
         Meteor.call 'deleteAnswer',
           type: type
           target: id,
@@ -149,7 +151,7 @@ describe 'deleteAnswer', ->
           touched_by: 'cjb'
           solved: null
           solved_by: null
-          tags: []
+          tags: {}
         oplogs = model.Messages.find(room_name: 'oplog/0').fetch()
         chai.assert.equal oplogs.length, 1
         chai.assert.include oplogs[0],

--- a/lib/methods/deletePuzzle.test.coffee
+++ b/lib/methods/deletePuzzle.test.coffee
@@ -43,7 +43,7 @@ describe 'deletePuzzle', ->
       solved: null
       solved_by: null
       incorrectAnswers: []
-      tags: []
+      tags: {}
       drive: 'ffoo'
       spreadsheet: 'sfoo'
       doc: 'dfoo'
@@ -58,7 +58,7 @@ describe 'deletePuzzle', ->
       solved_by: null
       puzzles: [id, 'another_puzzle']
       incorrectAnswers: []
-      tags: []
+      tags: {}
     ret = Meteor.call 'deletePuzzle',
       id: id
       who: 'cjb'
@@ -86,7 +86,7 @@ describe 'deletePuzzle', ->
       solved_by: null
       puzzles: ['another_puzzle']
       incorrectAnswers: []
-      tags: []
+      tags: {}
 
   it 'deletes drive', ->
     chai.assert.deepEqual driveMethods.deletePuzzle.getCall(0).args, ['ffoo']

--- a/lib/methods/deleteRound.test.coffee
+++ b/lib/methods/deleteRound.test.coffee
@@ -47,7 +47,7 @@ describe 'deleteRound', ->
         solved_by: null
         puzzles: []
         incorrectAnswers: []
-        tags: []
+        tags: {}
         drive: 'ffoo'
         spreadsheet: 'sfoo'
         doc: 'dfoo'
@@ -62,7 +62,7 @@ describe 'deleteRound', ->
         solved_by: null
         rounds: [id, 'another_round']
         incorrectAnswers: []
-        tags: []
+        tags: {}
       ret = Meteor.call 'deleteRound',
         id: id
         who: 'cjb'
@@ -90,7 +90,7 @@ describe 'deleteRound', ->
         solved_by: null
         rounds: ['another_round']
         incorrectAnswers: []
-        tags: []
+        tags: {}
 
     it 'deletes drive', ->
       chai.assert.deepEqual driveMethods.deletePuzzle.getCall(0).args, ['ffoo']
@@ -110,7 +110,7 @@ describe 'deleteRound', ->
         solved_by: null
         puzzles: ['foo1', 'foo2']
         incorrectAnswers: []
-        tags: []
+        tags: {}
       ret = Meteor.call 'deleteRound',
         id: id
         who: 'cjb'

--- a/lib/methods/deleteRoundGroup.test.coffee
+++ b/lib/methods/deleteRoundGroup.test.coffee
@@ -46,7 +46,7 @@ describe 'deleteRoundGroup', ->
         solved_by: null
         rounds: []
         incorrectAnswers: []
-        tags: []
+        tags: {}
       ret = Meteor.call 'deleteRoundGroup',
         id: id
         who: 'cjb'
@@ -78,7 +78,7 @@ describe 'deleteRoundGroup', ->
         solved_by: null
         rounds: ['foo1', 'foo2']
         incorrectAnswers: []
-        tags: []
+        tags: {}
       ret = Meteor.call 'deleteRoundGroup',
         id: id
         who: 'cjb'

--- a/lib/methods/incorrectCallIn.test.coffee
+++ b/lib/methods/incorrectCallIn.test.coffee
@@ -34,7 +34,7 @@ describe 'incorrectCallIn', ->
           touched_by: 'cscott'
           solved: null
           solved_by: null
-          tags: []
+          tags: {}
         callin = model.CallIns.insert
           name: 'Foo:precipitate'
           type: type

--- a/lib/methods/newCallIn.test.coffee
+++ b/lib/methods/newCallIn.test.coffee
@@ -55,7 +55,7 @@ describe 'newCallIn', ->
             touched_by: 'cscott'
             solved: null
             solved_by: null
-            tags: []
+            tags: {}
             incorrectAnswers: []
 
         describe 'with simple callin', ->
@@ -151,7 +151,7 @@ describe 'newCallIn', ->
       touched_by: 'cscott'
       solved: null
       solved_by: null
-      tags: []
+      tags: {}
       incorrectAnswers: []
     r = model.Rounds.insert
       name: 'Bar'
@@ -163,7 +163,7 @@ describe 'newCallIn', ->
       solved: null
       solved_by: null
       puzzles: [p]
-      tags: []
+      tags: {}
       incorrectAnswers: []
     Meteor.call 'newCallIn',
       type: 'puzzles'

--- a/lib/methods/newPuzzle.test.coffee
+++ b/lib/methods/newPuzzle.test.coffee
@@ -55,7 +55,7 @@ describe 'newPuzzle', ->
         drive: 'fid'
         spreadsheet: 'sid'
         doc: 'did'
-        tags: []
+        tags: {}
     
     it 'oplogs', ->
       chai.assert.lengthOf model.Messages.find({id: id, type: 'puzzles'}).fetch(), 1
@@ -78,7 +78,7 @@ describe 'newPuzzle', ->
         drive: 'fid'
         spreadsheet: 'sid'
         doc: 'did'
-        tags: []
+        tags: {}
       id2 = Meteor.call 'newPuzzle',
         name: 'Foo'
         who: 'cjb'

--- a/lib/methods/newRound.test.coffee
+++ b/lib/methods/newRound.test.coffee
@@ -59,7 +59,7 @@ describe 'newRound', ->
         drive: 'fid'
         spreadsheet: 'sid'
         doc: 'did'
-        tags: []
+        tags: {}
 
     it 'oplogs', ->
       chai.assert.lengthOf model.Messages.find({id: id, type: 'rounds'}).fetch(), 1
@@ -83,7 +83,7 @@ describe 'newRound', ->
         drive: 'fid'
         spreadsheet: 'sid'
         doc: 'did'
-        tags: []
+        tags: {}
       id2 = Meteor.call 'newRound',
         name: 'Foo'
         who: 'cjb'

--- a/lib/methods/newRoundGroup.test.coffee
+++ b/lib/methods/newRoundGroup.test.coffee
@@ -53,7 +53,7 @@ describe 'newRoundGroup', ->
         solved_by: null
         rounds: ['rd1']
         incorrectAnswers: []
-        tags: []
+        tags: {}
     
     it 'has no drive', ->
       group = model.RoundGroups.findOne id 
@@ -73,7 +73,7 @@ describe 'newRoundGroup', ->
         created_by: 'torgen'
         touched: 1
         touched_by: 'torgen'
-        tags: []
+        tags: {}
         solved: null
         solved_by: null
         incorrectAnswers: []

--- a/lib/methods/renamePuzzle.test.coffee
+++ b/lib/methods/renamePuzzle.test.coffee
@@ -49,7 +49,7 @@ describe 'renamePuzzle', ->
         drive: 'fid'
         spreadsheet: 'sid'
         doc: 'did'
-        tags: []
+        tags: {}
       ret = Meteor.call 'renamePuzzle',
         id: id
         name: 'Bar'
@@ -91,7 +91,7 @@ describe 'renamePuzzle', ->
         drive: 'f1'
         spreadsheet: 's1'
         doc: 'd1'
-        tags: []
+        tags: {}
       id2 = model.Puzzles.insert
         name: 'Bar'
         canon: 'bar'
@@ -106,7 +106,7 @@ describe 'renamePuzzle', ->
         drive: 'f2'
         spreadsheet: 's2'
         doc: 'd2'
-        tags: []
+        tags: {}
       ret = Meteor.call 'renamePuzzle',
         id: id1
         name: 'Bar'

--- a/lib/methods/renameRound.test.coffee
+++ b/lib/methods/renameRound.test.coffee
@@ -50,7 +50,7 @@ describe 'renameRound', ->
         drive: 'fid'
         spreadsheet: 'sid'
         doc: 'did'
-        tags: []
+        tags: {}
       ret = Meteor.call 'renameRound',
         id: id
         name: 'Bar'
@@ -92,7 +92,7 @@ describe 'renameRound', ->
         drive: 'f1'
         spreadsheet: 's1'
         doc: 'd1'
-        tags: []
+        tags: {}
       id2 = model.Rounds.insert
         name: 'Bar'
         canon: 'bar'
@@ -107,7 +107,7 @@ describe 'renameRound', ->
         drive: 'f2'
         spreadsheet: 's2'
         doc: 'd2'
-        tags: []
+        tags: {}
       ret = Meteor.call 'renameRound',
         id: id1
         name: 'Bar'

--- a/lib/methods/renameRoundGroup.test.coffee
+++ b/lib/methods/renameRoundGroup.test.coffee
@@ -46,7 +46,7 @@ describe 'renameRoundGroup', ->
         solved_by: null
         rounds: ['yoy']
         incorrectAnswers: []
-        tags: []
+        tags: {}
       ret = Meteor.call 'renameRoundGroup',
         id: id
         name: 'Bar'
@@ -84,7 +84,7 @@ describe 'renameRoundGroup', ->
         solved: null
         solved_by: null
         incorrectAnswers: []
-        tags: []
+        tags: {}
       id2 = model.RoundGroups.insert
         name: 'Bar'
         canon: 'bar'
@@ -95,7 +95,7 @@ describe 'renameRoundGroup', ->
         solved: null
         solved_by: null
         incorrectAnswers: []
-        tags: []
+        tags: {}
       ret = Meteor.call 'renameRoundGroup',
         id: id1
         name: 'Bar'

--- a/lib/methods/setAnswer.test.coffee
+++ b/lib/methods/setAnswer.test.coffee
@@ -24,7 +24,7 @@ describe 'setAnswer', ->
     id = model.Nicks.insert
       name: 'Torgen'
       canon: 'torgen'
-      tags: [{name: 'Real Name', canon: 'real_name', value: 'Dan Rosart', touched: 1, touched_by: 'torgen'}]
+      tags: real_name: {name: 'Real Name', value: 'Dan Rosart', touched: 1, touched_by: 'torgen'}
     chai.assert.throws ->
       Meteor.call 'setAnswer',
         type: 'nicks'
@@ -47,7 +47,7 @@ describe 'setAnswer', ->
             touched_by: 'torgen'
             solved: null
             solved_by: null
-            tags: [{name: 'Technology', canon: 'technology', value: 'Pottery', touched: 2, touched_by: 'torgen'}]
+            tags: technology: {name: 'Technology', value: 'Pottery', touched: 2, touched_by: 'torgen'}
           ret = Meteor.call 'setAnswer',
             type: type
             target: id
@@ -68,8 +68,9 @@ describe 'setAnswer', ->
             touched_by: 'cjb'
             solved: 7
             solved_by: 'cjb'
-            tags: [{name: 'Answer', canon: 'answer', value: 'bar', touched: 7, touched_by: 'cjb'},
-                    {name: 'Technology', canon: 'technology', value: 'Pottery', touched: 2, touched_by: 'torgen'}]
+            tags:
+              answer: {name: 'Answer', value: 'bar', touched: 7, touched_by: 'cjb'}
+              technology: {name: 'Technology', value: 'Pottery', touched: 2, touched_by: 'torgen'}
         
         it 'oplogs', ->
           oplogs = model.Messages.find(room_name: 'oplog/0').fetch()
@@ -96,8 +97,9 @@ describe 'setAnswer', ->
             touched_by: 'torgen'
             solved: 2
             solved_by: 'torgen'
-            tags: [{name: 'Answer', canon: 'answer', value: 'qux', touched: 2, touched_by: 'torgen'},
-                    {name: 'Technology', canon: 'technology', value: 'Pottery', touched: 2, touched_by: 'torgen'}]
+            tags:
+              answer: {name: 'Answer', value: 'qux', touched: 2, touched_by: 'torgen'}
+              technology: {name: 'Technology', value: 'Pottery', touched: 2, touched_by: 'torgen'}
           ret = Meteor.call 'setAnswer',
             type: type
             target: id
@@ -118,8 +120,9 @@ describe 'setAnswer', ->
             touched_by: 'cjb'
             solved: 7
             solved_by: 'cjb'
-            tags: [{name: 'Answer', canon: 'answer', value: 'bar', touched: 7, touched_by: 'cjb'},
-                    {name: 'Technology', canon: 'technology', value: 'Pottery', touched: 2, touched_by: 'torgen'}]
+            tags:
+              answer: {name: 'Answer', value: 'bar', touched: 7, touched_by: 'cjb'}
+              technology: {name: 'Technology', value: 'Pottery', touched: 2, touched_by: 'torgen'}
         
         it 'oplogs', ->
           oplogs = model.Messages.find(room_name: 'oplog/0').fetch()
@@ -147,8 +150,9 @@ describe 'setAnswer', ->
             touched_by: 'torgen'
             solved: 2
             solved_by: 'torgen'
-            tags: [{name: 'Answer', canon: 'answer', value: 'bar', touched: 2, touched_by: 'torgen'},
-                    {name: 'Technology', canon: 'technology', value: 'Pottery', touched: 2, touched_by: 'torgen'}]
+            tags:
+              answer: {name: 'Answer', value: 'bar', touched: 2, touched_by: 'torgen'}
+              technology: {name: 'Technology', value: 'Pottery', touched: 2, touched_by: 'torgen'}
           ret = Meteor.call 'setAnswer',
             type: type
             target: id
@@ -169,8 +173,9 @@ describe 'setAnswer', ->
             touched_by: 'torgen'
             solved: 2
             solved_by: 'torgen'
-            tags: [{name: 'Answer', canon: 'answer', value: 'bar', touched: 2, touched_by: 'torgen'},
-                    {name: 'Technology', canon: 'technology', value: 'Pottery', touched: 2, touched_by: 'torgen'}]
+            tags:
+              answer: {name: 'Answer', value: 'bar', touched: 2, touched_by: 'torgen'}
+              technology: {name: 'Technology', value: 'Pottery', touched: 2, touched_by: 'torgen'}
 
         it 'doesn\'t oplog', ->
           chai.assert.lengthOf model.Messages.find(room_name: 'oplog/0').fetch(), 0
@@ -185,7 +190,7 @@ describe 'setAnswer', ->
           touched_by: 'torgen'
           solved: null
           solved_by: null
-          tags: [{name: 'Status', canon: 'status', value: 'stuck', touched: 2, touched_by: 'torgen'}]
+          tags: status: {name: 'Status', value: 'stuck', touched: 2, touched_by: 'torgen'}
         chai.assert.isTrue Meteor.call 'setAnswer',
           type: type
           target: id
@@ -194,9 +199,10 @@ describe 'setAnswer', ->
           backsolve: true
           provided: true
         chai.assert.deepInclude model.collection(type).findOne(id),
-          tags: [{name: 'Answer', canon: 'answer', value: 'bar', touched: 7, touched_by: 'cjb'},
-                  {name: 'Backsolve', canon: 'backsolve', value: 'yes', touched: 7, touched_by: 'cjb'},
-                  {name: 'Provided', canon: 'provided', value: 'yes', touched: 7, touched_by: 'cjb'}]
+          tags:
+            answer: {name: 'Answer', value: 'bar', touched: 7, touched_by: 'cjb'}
+            backsolve: {name: 'Backsolve', value: 'yes', touched: 7, touched_by: 'cjb'}
+            provided: {name: 'Provided', value: 'yes', touched: 7, touched_by: 'cjb'}
 
       describe 'with matching callins', ->
         id = null
@@ -212,7 +218,7 @@ describe 'setAnswer', ->
             touched_by: 'torgen'
             solved: null
             solved_by: null
-            tags: []
+            tags: {}
           cid1 = model.CallIns.insert
             type: type
             target: id

--- a/lib/methods/summon.test.coffee
+++ b/lib/methods/summon.test.coffee
@@ -37,7 +37,7 @@ describe 'summon', ->
             touched_by: 'cjb'
             solved: 2
             solved_by: 'cjb'
-            tags: [{name: 'Answer', canon: 'answer', value: 'precipitate', touched: 2, touched_by: 'cjb'}]
+            tags: answer: {name: 'Answer', value: 'precipitate', touched: 2, touched_by: 'cjb'}
           ret = Meteor.call 'summon',
             who: 'torgen'
             type: type
@@ -52,7 +52,7 @@ describe 'summon', ->
             touched_by: 'cjb'
             solved: 2
             solved_by: 'cjb'
-            tags: [{name: 'Answer', canon: 'answer', value: 'precipitate', touched: 2, touched_by: 'cjb'}]
+            tags: answer: {name: 'Answer', value: 'precipitate', touched: 2, touched_by: 'cjb'}
 
         it 'doesn\'t chat', ->
           chai.assert.lengthOf model.Messages.find(room_name: $ne: 'oplog/0').fetch(), 0
@@ -73,7 +73,7 @@ describe 'summon', ->
             touched_by: 'cjb'
             solved: null
             solved_by: null
-            tags: [{name: 'Status', canon: 'status', value: 'Stuck on you', touched: 2, touched_by: 'cjb'}]
+            tags: status: {name: 'Status', value: 'Stuck on you', touched: 2, touched_by: 'cjb'}
           ret = Meteor.call 'summon',
             who: 'torgen'
             type: type
@@ -86,7 +86,7 @@ describe 'summon', ->
           chai.assert.deepInclude model.collection(type).findOne(id),
             touched: 7
             touched_by: 'torgen'
-            tags: [{name: 'Status', canon: 'status', value: 'Stuck like glue', touched: 7, touched_by: 'torgen'}]
+            tags: status: {name: 'Status', value: 'Stuck like glue', touched: 7, touched_by: 'torgen'}
 
         it 'doesn\'t chat', ->
           chai.assert.lengthOf model.Messages.find(room_name: $ne: 'oplog/0').fetch(), 0
@@ -107,7 +107,7 @@ describe 'summon', ->
             touched_by: 'cjb'
             solved: null
             solved_by: null
-            tags: [{name: 'Status', canon: 'status', value: 'everything is fine', touched: 2, touched_by: 'cjb'}]
+            tags: status: {name: 'Status', value: 'everything is fine', touched: 2, touched_by: 'cjb'}
           ret = Meteor.call 'summon',
             who: 'torgen'
             type: type
@@ -120,7 +120,7 @@ describe 'summon', ->
           chai.assert.deepInclude model.collection(type).findOne(id),
             touched: 7
             touched_by: 'torgen'
-            tags: [{name: 'Status', canon: 'status', value: 'Stuck like glue', touched: 7, touched_by: 'torgen'}]
+            tags: status: {name: 'Status', value: 'Stuck like glue', touched: 7, touched_by: 'torgen'}
 
         it 'notifies main chat', ->
           msgs = model.Messages.find(room_name: 'general/0').fetch()
@@ -148,7 +148,7 @@ describe 'summon', ->
             touched_by: 'cjb'
             solved: null
             solved_by: null
-            tags: []
+            tags: {}
         describe 'empty how', ->
           ret = null
           beforeEach ->
@@ -164,7 +164,7 @@ describe 'summon', ->
             chai.assert.deepInclude model.collection(type).findOne(id),
               touched: 7
               touched_by: 'torgen'
-              tags: [{name: 'Status', canon: 'status', value: 'Stuck', touched: 7, touched_by: 'torgen'}]
+              tags: status: {name: 'Status', value: 'Stuck', touched: 7, touched_by: 'torgen'}
 
           it 'notifies main chat', ->
             msgs = model.Messages.find(room_name: 'general/0').fetch()
@@ -197,7 +197,7 @@ describe 'summon', ->
             chai.assert.deepInclude model.collection(type).findOne(id),
               touched: 7
               touched_by: 'torgen'
-              tags: [{name: 'Status', canon: 'status', value: 'stucK like glue', touched: 7, touched_by: 'torgen'}]
+              tags: status: {name: 'Status', value: 'stucK like glue', touched: 7, touched_by: 'torgen'}
 
           it 'notifies main chat', ->
             msgs = model.Messages.find(room_name: 'general/0').fetch()
@@ -230,7 +230,7 @@ describe 'summon', ->
             chai.assert.deepInclude model.collection(type).findOne(id),
               touched: 7
               touched_by: 'torgen'
-              tags: [{name: 'Status', canon: 'status', value: 'Stuck: no idea', touched: 7, touched_by: 'torgen'}]
+              tags: status: {name: 'Status', value: 'Stuck: no idea', touched: 7, touched_by: 'torgen'}
 
           it 'notifies main chat', ->
             msgs = model.Messages.find(room_name: 'general/0').fetch()

--- a/lib/methods/unsummon.test.coffee
+++ b/lib/methods/unsummon.test.coffee
@@ -35,7 +35,7 @@ describe 'unsummon', ->
             touched_by: 'cjb'
             solved: null
             solved_by: null
-            tags: [{name: 'Status', canon: 'status', value: 'precipitate', touched: 2, touched_by: 'cjb'}]
+            tags: status: {name: 'Status', value: 'precipitate', touched: 2, touched_by: 'cjb'}
           ret = Meteor.call 'unsummon',
             who: 'torgen'
             type: type
@@ -48,7 +48,7 @@ describe 'unsummon', ->
           chai.assert.deepInclude model.collection(type).findOne(id),
             touched: 2
             touched_by: 'cjb'
-            tags: [{name: 'Status', canon: 'status', value: 'precipitate', touched: 2, touched_by: 'cjb'}]
+            tags: status: {name: 'Status', value: 'precipitate', touched: 2, touched_by: 'cjb'}
 
         it 'doesn\'t chat', ->
           chai.assert.lengthOf model.Messages.find(room_name: $ne: 'oplog/0').fetch(), 0
@@ -69,7 +69,7 @@ describe 'unsummon', ->
             touched_by: 'cjb'
             solved: null
             solved_by: null
-            tags: [{name: 'Status', canon: 'status', value: 'stuck', touched: 2, touched_by: 'cjb'}]
+            tags: status: {name: 'Status', value: 'stuck', touched: 2, touched_by: 'cjb'}
           ret = Meteor.call 'unsummon',
             who: 'torgen'
             type: type
@@ -82,7 +82,7 @@ describe 'unsummon', ->
           chai.assert.deepInclude model.collection(type).findOne(id),
             touched: 7
             touched_by: 'torgen'
-            tags: []
+            tags: {}
 
         it 'oplogs', ->
           chai.assert.lengthOf model.Messages.find({room_name: 'oplog/0', type: type, id: id}).fetch(), 1
@@ -112,7 +112,7 @@ describe 'unsummon', ->
             touched_by: 'cjb'
             solved: null
             solved_by: null
-            tags: [{name: 'Status', canon: 'status', value: 'stuck', touched: 2, touched_by: 'cjb'}]
+            tags: status: {name: 'Status', value: 'stuck', touched: 2, touched_by: 'cjb'}
           ret = Meteor.call 'unsummon',
             who: 'cjb'
             type: type
@@ -125,7 +125,7 @@ describe 'unsummon', ->
           chai.assert.deepInclude model.collection(type).findOne(id),
             touched: 7
             touched_by: 'cjb'
-            tags: []
+            tags: {}
 
         it 'oplogs', ->
           chai.assert.lengthOf model.Messages.find({room_name: 'oplog/0', type: type, id: id}).fetch(), 1

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -752,7 +752,7 @@ doc_id_to_link = (id) ->
       newObject "nicks",
         name: args.name
         who: args.name
-        tags: canonicalTags(args.tags or [], args.name)
+        tags: args.tags
       , {}, {suppressLog:true}
     renameNick: (args) ->
       renameObject "nicks", args, {suppressLog:true}

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -52,7 +52,7 @@ LastAnswer = BBCollection.last_answer = \
 #   solved_by:  timestamp of Nick who confirmed the answer
 #   incorrectAnswers: [ { answer: "Wrong", who: "answer submitter",
 #                         backsolve: ..., provided: ..., timestamp: ... }, ... ]
-#   tags: [ { name: "Status", canon: "status", value: "stuck" }, ... ]
+#   tags: status: { name: "Status", value: "stuck" }, ...
 #   rounds: [ array of round _ids, in order ]
 #   (next field is a bit racy, but it's fixed up by the server)
 #   round_start: integer, indicating how many rounds total are in all
@@ -74,7 +74,7 @@ if Meteor.isServer
 #   solved_by:  timestamp of Nick who confirmed the answer
 #   incorrectAnswers: [ { answer: "Wrong", who: "answer submitter",
 #                         backsolve: ..., provided: ..., timestamp: ... }, ... ]
-#   tags: [ { name: "Status", canon: "status", value: "stuck" }, ... ]
+#   tags: status: { name: "Status", value: "stuck" }, ... 
 #   puzzles: [ array of puzzle _ids, in order ]
 #   drive: google drive url or id
 Rounds = BBCollection.rounds = new Mongo.Collection "rounds"
@@ -94,7 +94,7 @@ if Meteor.isServer
 #   solved_by:  timestamp of Nick who confirmed the answer
 #   incorrectAnswers: [ { answer: "Wrong", who: "answer submitter",
 #                         backsolve: ..., provided: ..., timestamp: ... }, ... ]
-#   tags: [ { name: "Status", canon: "status", value: "stuck" }, ... ]
+#   tags: status: { name: "Status", value: "stuck" }, ... 
 #   drive: google drive url or id
 Puzzles = BBCollection.puzzles = new Mongo.Collection "puzzles"
 if Meteor.isServer
@@ -137,7 +137,7 @@ if Meteor.isServer
 #     The server throttles the updates from priv_located* to located* to
 #     prevent a N^2 blowup as everyone gets updates from everyone else
 #   priv_located_order: FIFO queue for location updates
-#   tags: [ { name: "Real Name", canon: "real_name", value: "C. Scott Ananian" }, ... ]
+#   tags: real_name: { name: "Real Name", value: "C. Scott Ananian" }, ... 
 # valid tags include "Real Name", "Gravatar" (email address to use for photos)
 Nicks = BBCollection.nicks = new Mongo.Collection "nicks"
 if Meteor.isServer
@@ -352,59 +352,25 @@ doc_id_to_link = (id) ->
     collection(type).remove(args.id)
     return true
 
-  setTagInternal = (args) ->
+  setTagInternal = (updateDoc, args) ->
     check args, ObjectWith
-      type: ValidType
-      object: IdOrObject
       name: NonEmptyString
       value: Match.Any
       who: NonEmptyString
       now: Number
-    id = args.object._id or args.object
-    now = args.now
-    canon = canonical(args.name)
-    loop
-      tags = collection(args.type).findOne(id).tags
-      # remove existing value for tag, if present
-      ntags = (tag for tag in tags when tag.canon isnt canon)
-      # add new tag, but keep tags sorted
-      ntags.push
-        name:args.name
-        canon:canon
-        value:args.value
-        touched: now
-        touched_by: canonical(args.who)
-      ntags.sort (a, b) -> (a?.canon or "").localeCompare (b?.canon or "")
-      # update the tag set only if there wasn't a race
-      numchanged = collection(args.type).update { _id: id, tags: tags }, $set:
-        tags: ntags
-        touched: now
-        touched_by: canonical(args.who)
-      # try again if this update failed due to a race (server only)
-      break unless Meteor.isServer and numchanged is 0
-    return true
+    updateDoc.$set ?= {}
+    updateDoc.$set["tags.#{canonical(args.name)}"] = 
+      name: args.name
+      value: args.value
+      touched: args.now
+      touched_by: canonical(args.who)
+    true
 
-  deleteTagInternal = (args) ->
-    check args, ObjectWith
-      type: ValidType
-      object: IdOrObject
-      name: NonEmptyString
-      who: NonEmptyString
-      now: Number
-    id = args.object._id or args.object
-    now = args.now
-    canon = canonical(args.name)
-    loop
-      tags = collection(args.type).findOne(id).tags
-      ntags = (tag for tag in tags when tag.canon isnt canon)
-      # update the tag set only if there wasn't a race
-      numchanged = collection(args.type).update { _id: id, tags: tags }, $set:
-        tags: ntags
-        touched: now
-        touched_by: canonical(args.who)
-      # try again if this update failed due to a race (server only)
-      break unless Meteor.isServer and numchanged is 0
-    return true
+  deleteTagInternal = (updateDoc, name) ->
+    check name, NonEmptyString
+    updateDoc.$unset ?= {}
+    updateDoc.$unset["tags.#{canonical(name)}"] = ''
+    true
 
   newDriveFolder = (type, id, name) ->
     check type, NonEmptyString
@@ -981,6 +947,10 @@ doc_id_to_link = (id) ->
     setTag: (args) ->
       check args, ObjectWith
         name: NonEmptyString
+        type: ValidType
+        object: IdOrObject
+        value: NonEmptyString
+        who: NonEmptyString
       # bail to setAnswer/deleteAnswer if this is the 'answer' tag.
       if canonical(args.name) is 'answer'
         return Meteor.call (if args.value then "setAnswer" else "deleteAnswer"),
@@ -992,11 +962,20 @@ doc_id_to_link = (id) ->
         args.fields = { link: args.value }
         return Meteor.call 'setField', args
       args.now = UTCNow() # don't let caller lie about the time
-      return setTagInternal args
+      updateDoc = $set:
+        touched: args.now
+        touched_by: canonical(args.who)
+      id = args.object._id or args.object
+      setTagInternal updateDoc, args
+      0 < collection(args.type).update id, updateDoc
 
     deleteTag: (args) ->
       check args, ObjectWith
         name: NonEmptyString
+        type: ValidType
+        object: IdOrObject
+        who: NonEmptyString
+      id = args.object._id or args.object
       # bail to deleteAnswer if this is the 'answer' tag.
       if canonical(args.name) is 'answer'
         return Meteor.call "deleteAnswer",
@@ -1007,7 +986,11 @@ doc_id_to_link = (id) ->
         args.fields = { link: null }
         return Meteor.call 'setField', args
       args.now = UTCNow() # don't let caller lie about the time
-      return deleteTagInternal args
+      updateDoc = $set:
+        touched: args.now
+        touched_by: canonical(args.who)
+      deleteTagInternal updateDoc, args.name
+      0 < collection(args.type).update id, updateDoc
 
     summon: (args) ->
       check args, ObjectWith
@@ -1024,14 +1007,14 @@ doc_id_to_link = (id) ->
       wasStuck = isStuck obj
       rawhow = args.how or 'Stuck'
       how = if rawhow.toLowerCase().startsWith('stuck') then rawhow else "Stuck: #{rawhow}"
-      setTagInternal
+      Meteor.call 'setTag',
         object: id
         type: args.type
         name: 'Status'
         value: how
         who: args.who
         now: UTCNow()
-      if wasStuck
+      if isStuck obj
         return
       oplog "Help requested for", args.type, id, args.who, 'stuck'
       body = "has requested help: #{rawhow}"
@@ -1062,8 +1045,8 @@ doc_id_to_link = (id) ->
       if not (isStuck obj)
         return "#{pretty_collection args.type} #{obj.name} isn't stuck"
       oplog "Help request cancelled for", args.type, id, args.who
-      sticker = (tag.touched_by for tag in obj.tags when tag.canon is 'status')?[0] or 'nobody'
-      deleteTagInternal
+      sticker = obj.tags.status?.touched_by
+      Meteor.call 'deleteTag',
         object: id
         type: args.type
         name: 'status'
@@ -1165,46 +1148,43 @@ doc_id_to_link = (id) ->
       id = args.target._id or args.target
 
       # Only perform the update and oplog if the answer is changing
-      oldAnswer = (tag for tag in collection(args.type).findOne(id).tags \
-                      when tag.canon is 'answer')[0]?.value
+      oldAnswer = collection(args.type).findOne(id)?.tags.answer?.value
       if oldAnswer is args.answer
         return false
 
       now = UTCNow()
-      setTagInternal
-        type: args.type
-        object: args.target
-        name: 'Answer'
-        value: args.answer
-        who: args.who
-        now: now
-      deleteTagInternal
-        type: args.type
-        object: args.target
-        name: 'status'
-        who: args.who
-        now: now
-      if args.backsolve
-        setTagInternal
-          type: args.type
-          object: args.target
-          name: 'Backsolve'
-          value: 'yes'
-          who: args.who
-          now: now
-      if args.provided
-        setTagInternal
-          type: args.type
-          object: args.target
-          name: 'Provided'
-          value: 'yes'
-          who: args.who
-          now: now
-      collection(args.type).update id, $set:
+      updateDoc = $set:
         solved: now
         solved_by: canonical(args.who)
         touched: now
         touched_by: canonical(args.who)
+      setTagInternal updateDoc,
+        name: 'Answer'
+        value: args.answer
+        who: args.who
+        now: now
+      deleteTagInternal updateDoc, 'status'
+      if args.backsolve
+        setTagInternal updateDoc,
+          name: 'Backsolve'
+          value: 'yes'
+          who: args.who
+          now: now
+      else
+        deleteTagInternal updateDoc, 'Backsolve'
+      if args.provided
+        setTagInternal updateDoc,
+          name: 'Provided'
+          value: 'yes'
+          who: args.who
+          now: now
+      else
+        deleteTagInternal updateDoc, 'Provided'
+      updated = collection(args.type).update
+        _id: id
+        'tags.answer.value': $ne: args.answer
+      , updateDoc
+      return false if updated is 0
       oplog "Found an answer (#{args.answer.toUpperCase()}) to", args.type, id, args.who, 'answers'
       # cancel any entries on the call-in queue for this puzzle
       for c in CallIns.find(type: args.type, target: id).fetch()
@@ -1252,29 +1232,15 @@ doc_id_to_link = (id) ->
         who: NonEmptyString
       id = args.target._id or args.target
       now = UTCNow()
-      deleteTagInternal
-        type: args.type
-        object: args.target
-        name: 'Answer'
-        who: args.who
-        now: now
-      deleteTagInternal
-        type: args.type
-        object: args.target
-        name: 'Backsolve'
-        who: args.who
-        now: now
-      deleteTagInternal
-        type: args.type
-        object: args.target
-        name: 'Provided'
-        who: args.who
-        now: now
-      collection(args.type).update id, $set:
+      updateDoc = $set:
         solved: null
         solved_by: null
         touched: now
         touched_by: canonical(args.who)
+      deleteTagInternal updateDoc, 'answer'
+      deleteTagInternal updateDoc, 'backsolve'
+      deleteTagInternal updateDoc, 'provided'
+      collection(args.type).update id, updateDoc
       oplog "Deleted answer for", args.type, id, args.who
       return true
 

--- a/server/batch.coffee
+++ b/server/batch.coffee
@@ -42,10 +42,11 @@ throttle = (func, wait = 0) ->
       Meteor.setTimeout(run, 0)
 
 if Meteor.settings.migrateTags
-  Meteor.startup ->
-    ['roundgroups', 'rounds', 'puzzles', 'nicks'].forEach (c) ->
-      model.collection(c).find(tags: $type: 4).forEach (o) ->
-        model.collection(c).update o._id, tags: $set: canonicalTags(o.tags, 'codexbot')
+  ['roundgroups', 'rounds', 'puzzles', 'nicks'].forEach (c) ->
+    model.collection(c).find().forEach (o) ->
+      return unless o.tags instanceof Array
+      console.log 'migrating', model.pretty_collection(c), o._id
+      model.collection(c).update o._id, $set: tags: canonicalTags(o.tags, 'codexbot')
 
 
 # Round groups

--- a/server/batch.coffee
+++ b/server/batch.coffee
@@ -2,7 +2,7 @@
 return unless share.DO_BATCH_PROCESSING
 
 import canonical from '../lib/imports/canonical.coffee'
-import { getTag } from '../lib/imports/tags.coffee'
+import { canonicalTags, getTag } from '../lib/imports/tags.coffee'
 
 model = share.model
 
@@ -40,6 +40,13 @@ throttle = (func, wait = 0) ->
     else
       running = true
       Meteor.setTimeout(run, 0)
+
+if Meteor.settings.migrateTags
+  Meteor.startup ->
+    ['roundgroups', 'rounds', 'puzzles', 'nicks'].forEach (c) ->
+      model.collection(c).find(tags: $type: 4).forEach (o) ->
+        model.collection(c).update o._id, tags: $set: canonicalTags(o.tags, 'codexbot')
+
 
 # Round groups
 updateRoundStart = ->


### PR DESCRIPTION
Objects are keyed by canonical form of tag name. This means more than one of them can be set in a single update, they can be set directly instead of requiring a racy read/write loop, they can be looked up in constant time instead of linear scan/binary search, and they can be used as sort keys or query criteria.
To migrate list-style tags to object-style tags, set migrateTags: true in your meteor settings. (This only needs to be done once.)