### PR TITLE
Propagate tags between meta and leaf puzzles

### DIFF
--- a/blackboard.less
+++ b/blackboard.less
@@ -113,6 +113,7 @@ body.has-emojis {
   h2 {
     color: #AAA;
   }
+  td.wanted { font-style: italic; }
   .answer > span:first-child {
     /* Vertically align answer timestamps */
     display: inline-block; min-width: 120px;

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -26,7 +26,12 @@ currentViewIs = (puzzle, view) ->
   return view is possible[0]
 
 Template.puzzle_info.helpers
-   tag: (name) -> (model.getTag this, name) or ''
+  tag: (name) -> (model.getTag this, name) or ''
+  caresAbout: ->
+    cared = model.getTag this, "Cares About"
+    cared?.split(',').forEach (tag) ->
+      name: tag
+      canon: model.canonical tag
 
 Template.puzzle.helpers
   data: ->

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -33,6 +33,13 @@ Template.puzzle_info.helpers
       name: tag
       canon: model.canonical tag
     ) for tag in cared?.split(',') or []
+  unsetcaredabout: ->
+    return [] if @type is 'rounds'
+    (
+      continue if model.getTag @puzzle, tag
+      tag
+    ) for tag in @round?.tags.cares_about?.value.split(',') or []
+
 
 Template.puzzle.helpers
   data: ->

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -36,6 +36,9 @@ Template.puzzle_info.helpers
   unsetcaredabout: ->
     return [] if @type is 'rounds'
     tag for tag in @round?.tags.cares_about?.value.split(',') or [] when not model.getTag @puzzle, tag
+  metapattern: ->
+    return [] if @type is 'rounds'
+    @round?.tags.pattern?.value
 
 
 Template.puzzle.helpers

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -27,11 +27,12 @@ currentViewIs = (puzzle, view) ->
 
 Template.puzzle_info.helpers
   tag: (name) -> (model.getTag this, name) or ''
-  caresAbout: ->
-    cared = model.getTag this, "Cares About"
-    cared?.split(',').forEach (tag) ->
+  caresabout: ->
+    cared = model.getTag @puzzle, "Cares About"
+    (
       name: tag
       canon: model.canonical tag
+    ) for tag in cared?.split(',') or []
 
 Template.puzzle.helpers
   data: ->

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -36,9 +36,9 @@ Template.puzzle_info.helpers
   unsetcaredabout: ->
     return [] if @type is 'rounds'
     tag for tag in @round?.tags.cares_about?.value.split(',') or [] when not model.getTag @puzzle, tag
-  metapattern: ->
+  metatags: ->
     return [] if @type is 'rounds'
-    @round?.tags.pattern?.value
+    tag for canon, tag of @round?.tags when /^meta /i.test tag.name
 
 
 Template.puzzle.helpers

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -35,10 +35,7 @@ Template.puzzle_info.helpers
     ) for tag in cared?.split(',') or []
   unsetcaredabout: ->
     return [] if @type is 'rounds'
-    (
-      continue if model.getTag @puzzle, tag
-      tag
-    ) for tag in @round?.tags.cares_about?.value.split(',') or []
+    tag for tag in @round?.tags.cares_about?.value.split(',') or [] when not model.getTag @puzzle, tag
 
 
 Template.puzzle.helpers

--- a/puzzle.html
+++ b/puzzle.html
@@ -21,7 +21,7 @@
 {{/each}}
 {{#each mtag in metatags}}
   <tr><td>{{mtag.name}}<br><i>(from {{round.name}})</i></td><td>{{mtag.value}}</td></tr>
-{{/let}}
+{{/each}}
 {{#with puzzle}}
   {{#each tags _id}}
     <tr><td class="tagname">{{name}}:</td><td class="tagvalue">{{value}}</td></tr>

--- a/puzzle.html
+++ b/puzzle.html
@@ -19,6 +19,11 @@
 {{#each cares in unsetcaredabout}}
   <tr><td>{{cares}}:</td><td class="wanted">(wanted by {{round.name}})</td></tr>
 {{/each}}
+{{#let pattern=metapattern}}
+  {{#if pattern}}
+    <tr><td>Pattern (from {{round.name}})</td><td>{{pattern}}</td></tr>
+  {{/if}}
+{{/let}}
 {{#with puzzle}}
   {{#each tags _id}}
     <tr><td class="tagname">{{name}}:</td><td class="tagvalue">{{value}}</td></tr>

--- a/puzzle.html
+++ b/puzzle.html
@@ -23,10 +23,16 @@
 {{> starred_messages canModify=mynick}}
 {{#if puzzles}}
 <table class="bb-round-answers table table-bordered table-condensed"><tbody>
-  <tr><th>Puzzle in round</th><th>Answer</th></tr>
+  {{#let cares=caresabout}}
+  <tr><th>Puzzle in round</th><th>Answer</th>{{#each cares}}<th>{{name}}</th>{{/each}}</tr>
   {{#each puzzles}}
-  <tr><td>{{link _id}}</td><td class="answer">{{#if solved}}{{tag "answer"}}{{/if}}</td></tr>
+  <tr><td>{{link _id}}</td><td class="answer">{{#if solved}}{{tag "answer"}}{{/if}}</td>
+  {{#each t in cares}}
+  <td>{{tag t.name}}</td>
   {{/each}}
+  </tr>
+  {{/each}}
+  {{/let}}
 </tbody></table>
 {{/if}}
 </template>

--- a/puzzle.html
+++ b/puzzle.html
@@ -21,7 +21,7 @@
 {{/each}}
 {{#let pattern=metapattern}}
   {{#if pattern}}
-    <tr><td>Pattern (from {{round.name}})</td><td>{{pattern}}</td></tr>
+    <tr><td>Pattern<br><i>(from {{round.name}})</i></td><td>{{pattern}}</td></tr>
   {{/if}}
 {{/let}}
 {{#with puzzle}}

--- a/puzzle.html
+++ b/puzzle.html
@@ -16,14 +16,9 @@
     <tr><td class="backsolve">{{#if backsolve}}(backsolved){{/if}}</td><td class="timestamp">{{pretty_ts timestamp}}</td></tr>
   {{/each}}
 {{/with}}
-{{#let cares=unsetcaredabout}}
-  {{#if cares.length}}
-    <tr>
-      <td>Metapuzzle {{round.name}} wants you to set tag{{#unless equal cares.length 1}}s{{/unless}}</td>
-      <td class="comma-list">{{#each cares}}<span>{{this}}</span>{{/each}}</td>
-    </tr>
-  {{/if}}
-{{/let}}
+{{#each cares in unsetcaredabout}}
+  <tr><td>{{cares}}:</td><td class="wanted">(wanted by {{round.name}})</td></tr>
+{{/each}}
 {{#with puzzle}}
   {{#each tags _id}}
     <tr><td class="tagname">{{name}}:</td><td class="tagvalue">{{value}}</td></tr>

--- a/puzzle.html
+++ b/puzzle.html
@@ -5,8 +5,8 @@
     {{#if puzzle.link}}(<a href="{{puzzle.link}}" target="_blank">link<i class="icon-share-alt"></i></a>){{/if}}
   </h2>
 </div>
+<table><tbody>
 {{#with puzzle}}
-  <table><tbody>
   {{#if solved}}
     <tr><td class="rightanswer">Answer:</td><td class="answer">{{tag "answer"}}</td></tr>
     <tr><td class="backsolve">{{#if tag "backsolved"}}(backsolved){{/if}}</td><td class="timestamp">{{pretty_ts solved}}</td></tr>
@@ -15,11 +15,21 @@
     <tr><td class="wronganswer">IncorrectAnswer:</td><td class="answer">{{answer}}</td></tr>
     <tr><td class="backsolve">{{#if backsolve}}(backsolved){{/if}}</td><td class="timestamp">{{pretty_ts timestamp}}</td></tr>
   {{/each}}
+{{/with}}
+{{#let cares=unsetcaredabout}}
+  {{#if cares.length}}
+    <tr>
+      <td>Metapuzzle {{round.name}} wants you to set tag{{#unless equal cares.length 1}}s{{/unless}}</td>
+      <td class="comma-list">{{#each cares}}<span>{{this}}</span>{{/each}}</td>
+    </tr>
+  {{/if}}
+{{/let}}
+{{#with puzzle}}
   {{#each tags _id}}
     <tr><td class="tagname">{{name}}:</td><td class="tagvalue">{{value}}</td></tr>
   {{/each}}
-  </tbody></table>
 {{/with}}
+</tbody></table>
 {{> starred_messages canModify=mynick}}
 {{#if puzzles}}
 <table class="bb-round-answers table table-bordered table-condensed"><tbody>

--- a/puzzle.html
+++ b/puzzle.html
@@ -19,10 +19,8 @@
 {{#each cares in unsetcaredabout}}
   <tr><td>{{cares}}:</td><td class="wanted">(wanted by {{round.name}})</td></tr>
 {{/each}}
-{{#let pattern=metapattern}}
-  {{#if pattern}}
-    <tr><td>Pattern<br><i>(from {{round.name}})</i></td><td>{{pattern}}</td></tr>
-  {{/if}}
+{{#each mtag in metatags}}
+  <tr><td>{{mtag.name}}<br><i>(from {{round.name}})</i></td><td>{{mtag.value}}</td></tr>
 {{/let}}
 {{#with puzzle}}
   {{#each tags _id}}

--- a/puzzle.html
+++ b/puzzle.html
@@ -20,7 +20,7 @@
   <tr><td>{{cares}}:</td><td class="wanted">(wanted by {{round.name}})</td></tr>
 {{/each}}
 {{#each mtag in metatags}}
-  <tr><td>{{mtag.name}}<br><i>(from {{round.name}})</i></td><td>{{mtag.value}}</td></tr>
+  <tr><td>{{mtag.name}}:<br><i>(from {{round.name}})</i></td><td>{{mtag.value}}</td></tr>
 {{/each}}
 {{#with puzzle}}
   {{#each tags _id}}


### PR DESCRIPTION
Any tag whose name starts with the word "meta" will display in the puzzle info of all puzzles in that round.
If a meta has a tag named "cares about", whose value contains a comma-separated list of tag names, a column will be added to the table of leaf puzzles in its puzzle info for each such tag name containing that puzzle's value for that tag. If the tag isn't set, a prompt to set it will be added to the leaf puzzle's puzzle info.