### PR TITLE
Add color to rounds to help distinguish them

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -43,3 +43,4 @@ meteortesting:mocha
 fds:coffeescript-share
 xolvio:cleaner
 accounts-base
+sha

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -83,6 +83,7 @@ retry@1.0.9
 routepolicy@1.0.12
 service-configuration@1.0.11
 session@1.1.7
+sha@1.0.9
 shell-server@0.3.1
 spacebars@1.0.15
 spacebars-compiler@1.1.3

--- a/blackboard.html
+++ b/blackboard.html
@@ -180,7 +180,7 @@
 
 <template name="blackboard_round">
   {{#if showRound }}
-  <tbody id="r{{round._id}}">
+  <tbody id="r{{round._id}}" style="background-color: {{color}}">
   <tr><th colspan="{{nCols}}">
   <h3 class="bb-editable" data-bbedit="rounds/{{round._id}}/title">
   {{#if editing "rounds" round._id "title"}}

--- a/blackboard.html
+++ b/blackboard.html
@@ -75,6 +75,10 @@
     <input type="checkbox" id="bb-compact-mode" checked="{{compactMode}}">
     Compact mode
   </label>
+  <label class="checkbox bb-boring-mode">
+    <input type="checkbox" id="bb-boring-mode" checked="{{boringMode}}">
+    Less Colorful
+  </label>
 </div>
 {{/unless}}
 </div>
@@ -180,7 +184,7 @@
 
 <template name="blackboard_round">
   {{#if showRound }}
-  <tbody id="r{{round._id}}" style="background-color: {{color}}">
+  <tbody id="r{{round._id}}" style="{{#unless boringMode}}background-color: {{color}}{{/unless}}">
   <tr><th colspan="{{nCols}}">
   <h3 class="bb-editable" data-bbedit="rounds/{{round._id}}/title">
   {{#if editing "rounds" round._id "title"}}

--- a/blackboard.html
+++ b/blackboard.html
@@ -463,6 +463,14 @@
           </td>
           <td class="bb-editable"
               data-bbedit="tags/{{id}}/{{canon}}/value">
+            {{#if equal canon "color"}}
+              {{#if canEdit}}
+                <input type="color" id="tags-{{id}}-{{canon}}-color"
+                       value="{{hexify value}}" />
+              {{else}}
+                <span class="bb-colorbox" style="background-color: {{value}}"></span>
+              {{/if}}
+            {{/if}}
             {{#if editing "tags" id canon "value"}}
               <input type="text" id="tags-{{id}}-{{canon}}-value"
                      value="{{value}}"

--- a/blackboard.less
+++ b/blackboard.less
@@ -369,11 +369,18 @@ body.has-emojis {
   }
   .bb-puzzle {
     margin-bottom: 0;
-    th { background: rgba(255,255,255,0.75); }
+    th {
+      background: rgba(255,255,255,0.75);
+      .boring & { background: #f8f8f8; }
+    }
     tr.meta, tr.puzzle {
       @bg: rgba(255,255,255,0.85);
       background: @bg;
       &.bb-status-stuck { background: repeating-linear-gradient(45deg, #FF0, #FF0 10px, @bg 10px, @bg 20px); }
+      .boring & {
+        background: white;
+        &.bb-status-stuck { background-color: #FF0; }
+      }
     }
     .bb-edit-icon, .bb-delete-icon {
       margin-top: 3px;

--- a/blackboard.less
+++ b/blackboard.less
@@ -211,6 +211,19 @@ body.has-emojis {
   .answer {
     text-transform: uppercase;
   }
+  .bb-colorbox {
+    display: inline-block;
+    width: 14px;
+    height:14px;
+    border: 1px white;
+    margin-right: 0.5em;
+  }
+  input[type=color] {
+    width: 14px;
+    height: 14px;
+    padding: 0px 0px;
+    margin-right: 0.5em;
+  }
 }
 
 #bb-right-sidebar {
@@ -374,7 +387,7 @@ body.has-emojis {
   }
   .bb-puzzle {
     margin-bottom: 0;
-    th {
+    th, tr.roundfooter {
       background: rgba(255,255,255,0.75);
       .boring & { background: #f8f8f8; }
     }

--- a/blackboard.less
+++ b/blackboard.less
@@ -371,8 +371,9 @@ body.has-emojis {
     margin-bottom: 0;
     th { background: rgba(255,255,255,0.75); }
     tr.meta, tr.puzzle {
-      background: rgba(255,255,255,0.85);
-      &.bb-status-stuck { background-color: #FF0; }
+      @bg: rgba(255,255,255,0.85);
+      background: @bg;
+      &.bb-status-stuck { background: repeating-linear-gradient(45deg, #FF0, #FF0 10px, @bg 10px, @bg 20px); }
     }
     .bb-edit-icon, .bb-delete-icon {
       margin-top: 3px;

--- a/blackboard.less
+++ b/blackboard.less
@@ -126,8 +126,13 @@ body.has-emojis {
   .bb-addquip-btn {
     float: right; margin-top: 4px; margin-right: 3px;
   }
-  .bb-status-stuck {
-    background-color: #FF0;
+  .bb-left-content, .bb-top-right-content {
+    background: rgba(255,255,255,0.85);
+    .bb-status-stuck { background: repeating-linear-gradient(45deg, #FF0, #FF0 20px, rgba(0,0,0,0) 20px, rgba(0,0,0,0) 40px); }
+    .boring & {
+      background: white;
+      .bb-status-stuck { background: #FF0; }
+    }
   }
 }
 .bb-chat-messages {

--- a/blackboard.less
+++ b/blackboard.less
@@ -369,7 +369,11 @@ body.has-emojis {
   }
   .bb-puzzle {
     margin-bottom: 0;
-    th { background: #f8f8f8; }
+    th { background: rgba(255,255,255,0.75); }
+    tr.meta, tr.puzzle {
+      background: rgba(255,255,255,0.85);
+      &.bb-status-stuck { background-color: #FF0; }
+    }
     .bb-edit-icon, .bb-delete-icon {
       margin-top: 3px;
     }

--- a/blackboard.less
+++ b/blackboard.less
@@ -213,16 +213,15 @@ body.has-emojis {
   }
   .bb-colorbox {
     display: inline-block;
-    width: 14px;
-    height:14px;
-    border: 1px white;
-    margin-right: 0.5em;
+    width: 12px;
+    height:12px;
+    border: 1px solid black;
   }
   input[type=color] {
     width: 14px;
     height: 14px;
     padding: 0px 0px;
-    margin-right: 0.5em;
+    margin-right: 0.25em;
   }
 }
 

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -270,7 +270,6 @@ Template.blackboard.events
     processBlackboardEdit[type]?(text, id, rest...) if text
 Template.blackboard.events okCancelEvents('.bb-editable input[type=text]',
   ok: (text, evt) ->
-    console.log 'ok fired'
     # find the data-bbedit specification for this field
     edit = $(evt.currentTarget).closest('*[data-bbedit]').attr('data-bbedit')
     [type, id, rest...] = edit.split('/')

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
 import { nickEmail } from './imports/nickEmail.coffee'
-import puzzleColor, { cssColorToHex } from './imports/objectColor.coffee'
+import puzzleColor, { cssColorToHex, hexToCssColor } from './imports/objectColor.coffee'
 
 model = share.model # import
 settings = share.settings # import
@@ -266,7 +266,7 @@ Template.blackboard.events
     edit = $(event.currentTarget).closest('*[data-bbedit]').attr('data-bbedit')
     [type, id, rest...] = edit.split('/')
     # strip leading/trailing whitespace from text (cancel if text is empty)
-    text = event.currentTarget.value.replace /^\s+|\s+$/, ''
+    text = hexToCssColor event.currentTarget.value.replace /^\s+|\s+$/, ''
     processBlackboardEdit[type]?(text, id, rest...) if text
 Template.blackboard.events okCancelEvents('.bb-editable input[type=text]',
   ok: (text, evt) ->
@@ -324,7 +324,6 @@ processBlackboardEdit =
           name: special
           canon: model.canonical(special)
           value: ''
-    # TODO(torgen): convert well known color hex codes to names
     # set tag (overwriting previous value)
     Meteor.call 'setTag', {type:n.type, object:id, name:t.name, value:text}
   link: (text, id) ->

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -205,6 +205,8 @@ Template.blackboard.events
     doBoolean 'hideRoundsSolvedMeta', event.target.checked
   "change .bb-compact-mode input": (event, template) ->
     doBoolean 'compactMode', event.target.checked
+  "change .bb-boring-mode input": (event, template) ->
+    doBoolean 'boringMode', event.target.checked
   "click .bb-hide-status": (event, template) ->
     doBoolean 'hideStatus', ('true' isnt reactiveLocalStorage.getItem 'hideStatus')
   "click .bb-add-round-group": (event, template) ->

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -1,6 +1,7 @@
 'use strict'
 
 import { nickEmail } from './imports/nickEmail.coffee'
+import puzzleColor from './imports/objectColor.coffee'
 
 model = share.model # import
 settings = share.settings # import
@@ -323,6 +324,7 @@ processBlackboardEdit =
 
 Template.blackboard_round.helpers
   hasPuzzles: -> (this.round?.puzzles?.length > 0)
+  color: -> puzzleColor @round if @round?
   showRound: ->
     return false if ('true' is reactiveLocalStorage.getItem 'hideRoundsSolvedMeta') and (this.round?.solved?)
     return ('true' isnt reactiveLocalStorage.getItem 'hideSolved') or (!this.round?.solved?) or

--- a/client/imports/objectColor.coffee
+++ b/client/imports/objectColor.coffee
@@ -1,0 +1,6 @@
+'use strict'
+
+import { getTag } from '../../lib/imports/tags.coffee'
+
+export default colorFromThingWithTags = (thing) ->
+  getTag(thing, 'color') or "##{SHA256(thing._id).substring(0,6)}"

--- a/client/imports/objectColor.coffee
+++ b/client/imports/objectColor.coffee
@@ -1,6 +1,7 @@
 'use strict'
 
 import { getTag } from '../../lib/imports/tags.coffee'
+import colornames from 'css-color-names'
 
 export default colorFromThingWithTags = (thing) ->
   getTag(thing, 'color') or "##{SHA256(thing._id).substring(0,6)}"
@@ -20,3 +21,8 @@ export cssColorToHex = (color) ->
   ctx.fillRect 0, 0, 1, 1
   [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data
   "##{numToHex r}#{numToHex g}#{numToHex b}"
+
+reversecolornames = {}
+for name, color of colornames
+  reversecolornames[color] = name
+export hexToCssColor = (hex) -> reversecolornames[hex] or hex

--- a/client/imports/objectColor.coffee
+++ b/client/imports/objectColor.coffee
@@ -8,13 +8,14 @@ export default colorFromThingWithTags = (thing) ->
 
 numToHex = (num) -> ('0' + num.toString 16).slice -2
 
+canvas = document.createElement 'canvas'
+[canvas.height, canvas.width] = [1, 1]
+ctx = canvas.getContext '2d'
+
 export cssColorToHex = (color) ->
   return color if /^#[0-9a-fA-F]{6}$/.test color
   if m = color.match /^#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])$/
     return "##{r}#{r}#{g}#{g}#{b}#{b}" if [x, r, g, b] = m
-  canvas = document.createElement 'canvas'
-  [canvas.height, canvas.width] = [1, 1]
-  ctx = canvas.getContext '2d'
   ctx.fillStyle = 'white'
   ctx.fillRect 0, 0, 1, 1
   ctx.fillStyle = color

--- a/client/imports/objectColor.coffee
+++ b/client/imports/objectColor.coffee
@@ -4,3 +4,19 @@ import { getTag } from '../../lib/imports/tags.coffee'
 
 export default colorFromThingWithTags = (thing) ->
   getTag(thing, 'color') or "##{SHA256(thing._id).substring(0,6)}"
+
+numToHex = (num) -> ('0' + num.toString 16).slice -2
+
+export cssColorToHex = (color) ->
+  return color if /^#[0-9a-fA-F]{6}$/.test color
+  if m = color.match /^#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])$/
+    return "##{r}#{r}#{g}#{g}#{b}#{b}" if [x, r, g, b] = m
+  canvas = document.createElement 'canvas'
+  [canvas.height, canvas.width] = [1, 1]
+  ctx = canvas.getContext '2d'
+  ctx.fillStyle = 'white'
+  ctx.fillRect 0, 0, 1, 1
+  ctx.fillStyle = color
+  ctx.fillRect 0, 0, 1, 1
+  [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data
+  "##{numToHex r}#{numToHex g}#{numToHex b}"

--- a/client/main.coffee
+++ b/client/main.coffee
@@ -42,6 +42,8 @@ Template.registerHelper 'compactHeader', () ->
 
 Template.registerHelper 'mynick', -> Meteor.user()?.nickname
 
+Template.registerHelper 'boringMode', -> 'true' is reactiveLocalStorage.getItem 'boringMode'
+
 # subscribe to the all-names feed all the time
 Meteor.subscribe 'all-names'
 # subscribe to all nicks all the time

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -1,4 +1,7 @@
 'use strict'
+
+import color from './imports/objectColor.coffee'
+
 model = share.model # import
 settings = share.settings # import
 
@@ -63,6 +66,7 @@ Template.puzzle.helpers
   vsizePlusHandle: -> +share.Splitter.vsize.get() + 6
   hsize: -> share.Splitter.hsize.get()
   currentViewIs: (view) -> currentViewIs @puzzle, view
+  color: -> color @puzzle
 
 Template.header_breadcrumb_extra_links.helpers
   currentViewIs: (view) -> currentViewIs this, view

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,11 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
       "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
     },
+    "css-color-names": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
+    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "codex-blackboard ================",
   "main": "index.js",
   "dependencies": {
-    "babel-runtime": "^6.26.0"
+    "babel-runtime": "^6.26.0",
+    "css-color-names": "0.0.4"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/page.html
+++ b/page.html
@@ -20,7 +20,7 @@ function onGoogleApiLoad() {
 
 <body>
   {{#if currentUser}}
-    <div id="bb-body">
+    <div id="bb-body" class="{{#if boringMode}}boring{{/if}}">
         {{> page }}
     </div>
     {{> header_confirmmodal}}

--- a/puzzle.html
+++ b/puzzle.html
@@ -49,7 +49,7 @@
 <div class="row-fluid bb-puzzleround">
  <!-- this is a puzzle page -->
 {{#with data}}
-<div class="bb-splitter" style="padding-right: {{hsize}}px">
+<div class="bb-splitter" style="padding-right: {{hsize}}px; {{#unless boringMode}}background: {{color}}{{/unless}}">
   <div class="bb-left-content">{{! start left of splitter }}
   {{#if puzzle.spreadsheet}}
     <div class="bb-left-header" style="{{#unless currentViewIs "spreadsheet"}}display: none;{{/unless}}">

--- a/puzzle.html
+++ b/puzzle.html
@@ -24,7 +24,13 @@
 {{/each}}
 {{#with puzzle}}
   {{#each tags _id}}
-    <tr><td class="tagname">{{name}}:</td><td class="tagvalue">{{value}}</td></tr>
+    <tr>
+      <td class="tagname">{{name}}:</td>
+      <td class="tagvalue">
+        {{#if equal canon "color"}}<span class="bb-colorbox" style="background-color: {{value}}"></span>{{/if}}
+        {{value}}
+      </td>
+    </tr>
   {{/each}}
 {{/with}}
 </tbody></table>


### PR DESCRIPTION
Also adds color to background of puzzle info frame to help distinguish it from that of its round. Colors are based on hash of round/puzzle id by default, but can be set with color tag, for which a color picker is provided on the blackboard in edit mode.