### PR TITLE
Eliminate fixed paging and OldMessages collection

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -56,7 +56,7 @@
 </template>
 
 <template name="starred_messages">
-  {{#if messages}}
+  {{#if messages.count}}
   <div class="bb-chat-messages bb-starred-messages {{#if canModify}}can-modify-star{{/if}}">
     <h3>Starred Messages</h3>
     {{#each messages}}
@@ -67,13 +67,13 @@
 </template>
 
 <template name="media_message">
-<div class="media{{#if message.to}} bb-message-pm{{/if}}" data-nick="{{message.nick}}" data-pm-to="{{message.to}}">
+<div class="bb-message media{{#if message.to}} bb-message-pm{{/if}}{{#if message.starred}} starred{{/if}}" data-nick="{{message.nick}}" data-pm-to="{{message.to}}">
   {{gravatar id=email image="wavatar" size=48 classes="media-object pull-left img-rounded" }}
   <div class="media-body bb-message-body">
     <div class="pull-right timestamp">{{pretty_ts message.timestamp}}</div>
     {{#unless message.to}}
       {{! can't star a PM. }}
-      <div class="bb-message-star {{#if message.starred}}starred{{/if}}"></div>
+      <div class="bb-message-star"></div>
     {{/unless}}
     <h5 class="media-heading"><span title="{{message.nick}}{{nickLocation message.nick}}" class="{{#if nickNear message.nick}}near{{/if}}">{{nickOrName message.nick}}</span>
           {{#if message.to}}
@@ -108,16 +108,19 @@
 
 <template name="messages">
   <div id="messages" class="row-fluid bb-chat-messages {{#if mynick}}can-modify-star{{/if}}">
-    {{#if ready}}{{#if prevTimestamp}}
-      <p align="center">
-        <a href="{{prevTimestamp}}" class="chat-link">See earlier messages</a>
-      </p>
-    {{else if timestamp}}
-      <p align="center">Start of chat log.</p>
-    {{/if}}{{/if}}
+    {{#if ready}}
+      {{#if startOfChannel}}
+        <button disabled="" class="btn btn-small btn-block btn-info bb-chat-start">No earlier messages</button>
+      {{else}}
+        <button class="btn btn-small btn-info btn-block bb-chat-load-more">Load more messages</button>
+      {{/if}}
+    {{else}}
+      <button class="btn btn-small btn-info btn-block active bb-chat-loading">Loading <i class="fas fa-spin fa-spinner"></i></button>
+    {{/if}}
     {{#each messages}}{{scrollHack}}
-      {{#if message.presence}}
-<div class="bb-message-presence {{message.presence}}" title={{body}}>
+      {{#if message.dawn_of_time}}<!-- Channel creation -->
+      {{else if message.presence}}
+<div class="bb-message-presence {{message.presence}}" title="{{body}}">
   {{gravatar id=email image="wavatar" size=14 }}{{message.nick}}
 </div>
       {{else if message.system}}
@@ -126,7 +129,7 @@
      {{body}}
 </div>
       {{else if usefulEnough message}}
-        {{# if message.action}}
+        {{#if message.action}}
 <div class="bb-message-action" data-nick="{{message.nick}}">
    <div class="pull-right timestamp">{{pretty_ts message.timestamp}}</div>
      <i class="fas fa-hand-point-right"></i>
@@ -139,25 +142,8 @@
       {{#if isLastRead message.timestamp}}
 <div class="bb-message-last-read">read</div>
       {{/if}}
-    {{else}}
-      <p align="center">
-{{#if ready}}
-No chat messages{{#if timestamp}} before {{pretty_ts timestamp}}{{/if}}.
-{{else}}
-...loading messages...
-{{/if}}
-      </p>
     {{/each}}
-
-    {{#if timestamp}}{{#if ready}}
-      <p align="center">
-      {{#if nextTimestamp}}
-      <a href="{{nextTimestamp}}" class="chat-link">See next page of logs</a>;
-      {{/if}}
-      <a href="/chat/{{room_name}}" class="chat-link">See most recent logs</a>
-      </p>
-    {{/if}}{{/if}}
     {{! Ensure there's always a small "last-child" here to scroll to.}}
-    <p id=chat-bottom></p>
+    <p id="chat-bottom"></p>
   </div>
 </template>

--- a/chat.less
+++ b/chat.less
@@ -58,24 +58,22 @@
     display: inline-block;
     float: right;
     padding-right: 0.3em;
+    color: lightgrey;
     &:before {
       font-family: "Font Awesome 5 Free";
       content: "\f005 ";
     }
-    &.starred {
-      color: palegoldenrod;
-      font-weight: 900;
-    } 
-    &:not(.starred) {
-      color: lightgrey;
-    } 
+  }
+  .starred .bb-message-star {
+    color: palegoldenrod;
+    font-weight: 900;
   } 
-  &.can-modify-star .bb-message-star {
-    &.starred {
-      color: gold;
-    }
-    &:not(.starred) {
+  &.can-modify-star {
+    .bb-message-star {
       color: black;
+    }
+    .starred .bb-message-star {
+      color: gold;
     }
   }
   .media {

--- a/client/000startup/settings.coffee
+++ b/client/000startup/settings.coffee
@@ -19,6 +19,10 @@ settings.NAME_PLACEHOLDER = server.namePlaceholder ? 'J. Random Codexian'
 
 settings.WHOSE_GITHUB = server.whoseGitHub ? 'cjb'
 
+settings.INITIAL_CHAT_LIMIT = server.initialChatLimit ? 200
+
+settings.CHAT_LIMIT_INCREMENT = server.chatLimitIncrement ? 100
+
 # -- Performance settings --
 
 # make fewer people subscribe to ringhunters chat.

--- a/client/chat.coffee
+++ b/client/chat.coffee
@@ -14,43 +14,10 @@ Session.setDefault
   room_name: 'general/0'
   type:      'general'
   id:        '0'
-  timestamp: 0
   chatReady: false
+  limit:     settings.INITIAL_CHAT_LIMIT
 
-# Chat/pagination helpers!
-
-# subscribe to last-page feed all the time
-lastPageSub = Meteor.subscribe 'last-pages'
-
-# helper method, using the `ready` signal from lastPageSub
-# returns `null` iff subscriptions are not ready.
-pageForTimestamp = (room_name, timestamp=0, subscribe=false) ->
-  timestamp = +timestamp
-  if timestamp is 0
-    return null unless lastPageSub.ready()
-    p = model.Pages.findOne(room_name:room_name, next:null)
-    return {
-      _id: p?._id
-      room_name: room_name
-      from: p?.from or 0
-      to: 0 # means "and everything else" for message-in-range subscription
-    }
-  else
-    if subscribe and Tracker.active # make sure we unsubscribe if necessary!
-      ctx = subscribe?.subscribe or Meteor
-      ctx.subscribe 'page-by-timestamp', room_name, timestamp
-    model.Pages.findOne(room_name:room_name, to:timestamp)
-
-# helper method to filter messages to match a given page object
-messagesForPage = (p, opts={}) ->
-  unless p? # return empty cursor unless p is non-null
-    return model.Messages.find(timestamp:model.NOT_A_TIMESTAMP)
-  cond = $gte: +p.from, $lt: +p.to
-  delete cond.$lt if cond.$lt is 0
-  model.Messages.find
-    room_name: p.room_name
-    timestamp: cond
-  , opts
+# Chat helpers!
 
 # compare to: computeMessageFollowup in lib/model.coffee
 computeMessageFollowup = (prev, curr) ->
@@ -130,10 +97,10 @@ Template.starred_messages.helpers
       transform: messageTransform
 
 Template.media_message.events
-  'click .bb-message-star.starred': (event, template) ->
+  'click .bb-message.starred .bb-message-star': (event, template) ->
     return unless $(event.target).closest('.can-modify-star').size() > 0
     Meteor.call 'setStarred', this._id, false
-  'click .bb-message-star:not(.starred)': (event, template) ->
+  'click .bb-message:not(.starred) .bb-message-star': (event, template) ->
     return unless $(event.target).closest('.can-modify-star').size() > 0
     Meteor.call 'setStarred', this._id, true
 
@@ -191,10 +158,12 @@ messageTransform = (m) ->
 # Template Binding
 Template.messages.helpers
   room_name: -> Session.get('room_name')
-  timestamp: -> +Session.get('timestamp')
   ready: -> Session.equals('chatReady', true) and \
             Template.instance().subscriptionsReady()
   isLastRead: (ts) -> Session.equals('lastread', +ts)
+  # The dawn of time message has ID equal to the room name because it's
+  # efficient to find it that way on the client, where there are no indexes.
+  startOfChannel: -> model.Messages.findOne(_id: Session.get 'room_name')?
   usefulEnough: (m) ->
     # test Session.get('nobot') last to get a fine-grained dependency
     # on the `nobot` session variable only for 'useless' messages
@@ -206,24 +175,13 @@ Template.messages.helpers
             not m.useless_cmd) or \
         doesMentionNick(m) or \
         ('true' isnt reactiveLocalStorage.getItem 'nobot')
-  prevTimestamp: ->
-    p = pageForTimestamp Session.get('room_name'), +Session.get('timestamp')
-    return unless p?.from
-    "/chat/#{p.room_name}/#{p.from}"
-  nextTimestamp: ->
-    p = pageForTimestamp Session.get('room_name'), +Session.get('timestamp')
-    return unless p?.next?
-    p = model.Pages.findOne(p.next)
-    return unless p?
-    "/chat/#{p.room_name}/#{p.to}"
   messages: ->
     room_name = Session.get 'room_name'
     # I will go out on a limb and say we need this because transform uses
     # doesMentionNick and transforms aren't usually reactive, so we need to
     # recompute them if you log in as someone else.
     Meteor.userId()
-    p = pageForTimestamp room_name, +Session.get('timestamp')
-    return messagesForPage p,
+    return model.Messages.find {room_name},
       sort: [['timestamp','asc']]
       transform: messageTransform
       
@@ -242,7 +200,13 @@ Template.messages.helpers
 
 Template.messages.onCreated ->
   instachat.scrolledToBottom = true
-  this.autorun =>
+  @autorun =>
+    # put this in a separate autorun so it's not invalidated needlessly when
+    # the limit changes.
+    room_name = Session.get 'room_name'
+    return unless room_name
+    @subscribe 'presence-for-room', room_name
+  @autorun =>
     invalidator = =>
       instachat.ready = false
       Session.set 'chatReady', false
@@ -250,17 +214,29 @@ Template.messages.onCreated ->
     invalidator()
     room_name = Session.get 'room_name'
     return unless room_name
-    this.subscribe 'presence-for-room', room_name
-    timestamp = (+Session.get('timestamp'))
-    p = pageForTimestamp room_name, timestamp, {subscribe: this}
-    return unless p? # wait until page information is loaded
-    if p.next? # subscribe to the 'next' page
-      this.subscribe 'page-by-id', p.next
     # load messages for this page
-    onReady = ->
+    onReady = =>
       instachat.ready = true
       Session.set 'chatReady', true
-    this.subscribe 'messages-in-range', p.room_name, p.from, p.to,
+      return unless @limitRaise?
+      [[firstMessage, offset], @limitRaise] = [@limitRaise, undefined]
+      Tracker.afterFlush =>
+        # only scroll if the button is visible, since it means we were at the
+        # top and are still there. If we were anywhere else, the window would
+        # have stayed put.
+        messages = @$('#messages')[0]
+        chatStart = @$('.bb-chat-load-more, .bb-chat-start')[0]
+        return unless chatStart.getBoundingClientRect().bottom > messages.offsetTop
+        # We can't just scroll the last new thing into view because of the header.
+        # we have to find the thing whose offset top is as much above the message
+        # we want to keep in view as the offset top of the messages element.
+        # We would have to loop to find firstMessage's index in messages.children,
+        # so just iterate backwards. Shouldn't take too long to find ~100 pixels.
+        currMessage = firstMessage
+        while currMessage? and firstMessage.offsetTop - currMessage.offsetTop < offset
+          currMessage = currMessage.previousElementSibling
+        currMessage?.scrollIntoView()
+    @subscribe 'recent-messages', room_name, Session.get('limit'),
       onReady: onReady
     Tracker.onInvalidate invalidator
 
@@ -276,6 +252,16 @@ Template.messages.onRendered ->
     $("#messages").each ->
       console.log "Observing #{this}" unless Meteor.isProduction
       instachat.mutationObserver.observe(this, {childList: true})
+
+Template.messages.events
+  'click .bb-chat-load-more': (event, template) ->
+    firstMessage = event.currentTarget.nextElementSibling
+    offset = firstMessage.offsetTop
+    # Skip starred messages because they might be loaded by a different publish.
+    while firstMessage.classList.contains 'starred'
+      firstMessage = firstMessage.nextElementSibling
+    template.limitRaise = [firstMessage, offset]
+    Session.set 'limit', Session.get('limit') + settings.CHAT_LIMIT_INCREMENT
 
 whos_here_helper = ->
   roomName = Session.get('type') + '/' + Session.get('id')
@@ -361,11 +347,8 @@ prettyRoomName = ->
     model.Names.findOne(id)?.name
   return (name or "unknown")
 
-joinRoom = (type, id, timestamp) ->
-  roomName = type + '/' + id
-  # xxx: could record the room name in a set here.
-  Session.set "room_name", roomName
-  share.Router.goToChat(type, id, timestamp ? Session.get('timestamp'))
+joinRoom = (type, id) ->
+  share.Router.goToChat type, id
   Tracker.afterFlush -> scrollMessagesView()
   $("#messageInput").select()
   startupChat()
@@ -442,12 +425,12 @@ $(document).on 'submit', '#joinRoom', ->
     $("#roomName").val prettyRoomName()
   # is this the general room?
   else if model.canonical(roomName) is model.canonical(GENERAL_ROOM)
-    joinRoom "general", "0", 0
+    joinRoom "general", "0"
   else
     # try to find room as a group, round, or puzzle name
     n = model.Names.findOne canon: model.canonical(roomName)
     if n
-      joinRoom n.type, n._id, 0
+      joinRoom n.type, n._id
     else
       # reset to old room name
       $("#roomName").val prettyRoomName()
@@ -495,7 +478,7 @@ Template.messages_input.submit = (message) ->
           return Meteor.call 'newMessage', args
         hideMessageAlert()
         cleanupChat()
-        joinRoom result.type, result.object._id, 0
+        joinRoom result.type, result.object._id
     when "/msg", "/m"
       # find who it's to
       [to, rest] = rest.split(/\s+([^]*)/, 2)
@@ -523,9 +506,6 @@ Template.messages_input.submit = (message) ->
   # on the newMessage call, which makes the below ineffective.  But leave
   # it here in case we turn latency compensation back on.
   Tracker.afterFlush -> scrollMessagesView()
-  # make sure we're looking at the most recent messages
-  if (+Session.get('timestamp'))
-    share.Router.navigate "/chat/#{Session.get 'room_name'}", {trigger:true}
   return
 Template.messages_input.events
   "keydown textarea": (event, template) ->
@@ -576,8 +556,6 @@ $(document).on 'focus', '#messageInput', ->
   hideMessageAlert()
 
 updateLastRead = ->
-  timestamp = (+Session.get('timestamp')) or Number.MAX_VALUE
-  return unless timestamp is Number.MAX_VALUE # don't update if we're paged back
   lastMessage = model.Messages.findOne
     room_name: Session.get 'room_name'
   ,
@@ -713,8 +691,5 @@ share.chat =
   cleanupChat: cleanupChat
   hideMessageAlert: hideMessageAlert
   joinRoom: joinRoom
-  # pagination helpers
-  pageForTimestamp: pageForTimestamp
-  messagesForPage: messagesForPage
   # for debugging
   instachat: instachat

--- a/client/header.coffee
+++ b/client/header.coffee
@@ -524,12 +524,13 @@ confirmationDialog = share.confirmationDialog = (options) ->
   Template.header_confirmmodal_contents.cancel = true
   Session.set 'confirmModalVisible', (options or Object.create(null))
 
+OPLOG_COLLAPSE_LIMIT = 10
+
 ############## operation log in header ####################
 Template.header_lastupdates.helpers
   lastupdates: ->
-    LIMIT = 10
     ologs = model.Messages.find {room_name: "oplog/0"}, \
-          {sort: [["timestamp","desc"]], limit: LIMIT}
+          {sort: [["timestamp","desc"]], limit: OPLOG_COLLAPSE_LIMIT}
     ologs = ologs.fetch()
     # now look through the entries and collect similar logs
     # this way we can say "New puzzles: X, Y, and Z" instead of just
@@ -558,14 +559,14 @@ Template.header_lastupdates.helpers
 # subscribe when this template is in use/unsubscribe when it is destroyed
 Template.header_lastupdates.onCreated ->
   this.autorun =>
-    p = share.chat.pageForTimestamp 'oplog/0', 0, {subscribe:this}
-    return unless p? # wait until page info is loaded
-    this.subscribe 'messages-in-range', p.room_name, p.from, p.to
+    this.subscribe 'recent-messages', 'oplog/0', OPLOG_COLLAPSE_LIMIT
 # add tooltip to 'more' links
 do ->
   for t in ['header_lastupdates', 'header_lastchats']
     Template[t].onRendered ->
       $(this.findAll('.right a[title]')).tooltip placement: 'left'
+
+RECENT_GENERAL_LIMIT = 2
 
 ############## chat log in header ####################
 Template.header_lastchats.helpers
@@ -573,7 +574,7 @@ Template.header_lastchats.helpers
     LIMIT = 2
     m = model.Messages.find {
       room_name: "general/0", system: false, bodyIsHtml: false
-    }, {sort: [["timestamp","desc"]], limit: LIMIT}
+    }, {sort: [["timestamp","desc"]], limit: RECENT_GENERAL_LIMIT}
     m = m.fetch().reverse()
     return m
   msgbody: ->
@@ -583,7 +584,5 @@ Template.header_lastchats.helpers
 # subscribe when this template is in use/unsubscribe when it is destroyed
 Template.header_lastchats.onCreated ->
   return if settings.BB_DISABLE_RINGHUNTERS_HEADER
-  this.autorun =>
-    p = share.chat.pageForTimestamp 'general/0', 0, {subscribe:this}
-    return unless p? # wait until page info is loaded
-    this.subscribe 'messages-in-range', p.room_name, p.from, p.to
+  @autorun =>
+    @subscribe 'recent-header-messages'

--- a/client/header.coffee
+++ b/client/header.coffee
@@ -571,9 +571,8 @@ RECENT_GENERAL_LIMIT = 2
 ############## chat log in header ####################
 Template.header_lastchats.helpers
   lastchats: ->
-    LIMIT = 2
     m = model.Messages.find {
-      room_name: "general/0", system: false, bodyIsHtml: false
+      room_name: "general/0", system: {$ne: true}, bodyIsHtml: {$ne: true}
     }, {sort: [["timestamp","desc"]], limit: RECENT_GENERAL_LIMIT}
     m = m.fetch().reverse()
     return m

--- a/client/header.coffee
+++ b/client/header.coffee
@@ -560,8 +560,7 @@ Template.header_lastupdates.onCreated ->
   this.autorun =>
     p = share.chat.pageForTimestamp 'oplog/0', 0, {subscribe:this}
     return unless p? # wait until page info is loaded
-    messages = if p.archived then "oldmessages" else "messages"
-    this.subscribe "#{messages}-in-range", p.room_name, p.from, p.to
+    this.subscribe 'messages-in-range', p.room_name, p.from, p.to
 # add tooltip to 'more' links
 do ->
   for t in ['header_lastupdates', 'header_lastchats']
@@ -587,5 +586,4 @@ Template.header_lastchats.onCreated ->
   this.autorun =>
     p = share.chat.pageForTimestamp 'general/0', 0, {subscribe:this}
     return unless p? # wait until page info is loaded
-    messages = if p.archived then "oldmessages" else "messages"
-    this.subscribe "#{messages}-in-range", p.room_name, p.from, p.to
+    this.subscribe 'messages-in-range', p.room_name, p.from, p.to

--- a/client/imports/nickEmail.coffee
+++ b/client/imports/nickEmail.coffee
@@ -5,6 +5,7 @@ import canonical from '../../lib/imports/canonical.coffee'
 export emailFromNickObject = (nick) -> nick.gravatar or "#{nick._id}@#{share.settings.DEFAULT_HOST}"  
 
 export nickEmail = (nick) ->
+  return unless nick?
   cn = canonical nick
   n = Meteor.users.findOne cn
   return "" unless n?

--- a/client/main.coffee
+++ b/client/main.coffee
@@ -64,7 +64,6 @@ Meteor.subscribe 'all-nicks'
 # we might subscribe to all-roundsandpuzzles, too.
 if settings.BB_SUB_ALL
   Meteor.subscribe 'all-roundsandpuzzles'
-# we also always subscribe to the last-pages feed; see chat.coffee
 
 keystring = (k) -> "notification.stream.#{k}"
 
@@ -130,9 +129,8 @@ Meteor.startup ->
   suppress = true
   Tracker.autorun ->
     return if share.notification.count() is 0 # unsubscribes
-    p = share.chat.pageForTimestamp 'oplog/0', 0, {subscribe:true}
-    return unless p? # wait until page info is loaded
-    Meteor.subscribe 'messages-in-range', p.room_name, p.from, p.to,
+    # Limits spam if you 
+    Meteor.subscribe 'oplogs-since', now,
       onStop: -> suppress = true
       onReady: -> suppress = false
   share.model.Messages.find({room_name: 'oplog/0', timestamp: $gte: now}).observeChanges
@@ -191,8 +189,7 @@ BlackboardRouter = Backbone.Router.extend
     "puzzles/:puzzle": "PuzzlePage"
     "puzzles/:puzzle/:view": "PuzzlePage"
     "chat/:type/:id": "ChatPage"
-    "chat/:type/:id/:timestamp": "ChatPage"
-    "oplogs/:timestamp": "OpLogPage"
+    "oplogs": "OpLogPage"
     "callins": "CallInPage"
     "quips/:id": "QuipPage"
     "facts": "FactsPage"
@@ -221,14 +218,12 @@ BlackboardRouter = Backbone.Router.extend
   RoundPage: (id) ->
     this.goToChat "rounds", id, 0
 
-  ChatPage: (type,id,timestamp=0) ->
+  ChatPage: (type,id) ->
     id = "0" if type is "general"
     this.Page("chat", type, id)
-    Session.set "timestamp", +timestamp
 
-  OpLogPage: (timestamp) ->
+  OpLogPage: ->
     this.Page("oplog", "oplog", "0")
-    Session.set "timestamp", timestamp
 
   CallInPage: ->
     this.Page("callins", "callins", "0")
@@ -245,10 +240,10 @@ BlackboardRouter = Backbone.Router.extend
     # proper subscriptions, etc; plus launch a background process
     # to perform database mutations
     cb = (args) =>
-      {page,type,id,timestamp} = args
+      {page,type,id} = args
       url = switch page
-        when 'chat' then this.chatUrlFor type, id, timestamp
-        when 'oplogs' then this.urlFor 'oplogs', timestamp # bit of a hack
+        when 'chat' then this.chatUrlFor type, id
+        when 'oplogs' then this.urlFor 'oplogs' # bit of a hack
         when 'blackboard' then Meteor._relativeToSiteRootUrl "/"
         when 'facts' then this.urlFor 'facts', '' # bit of a hack
         else this.urlFor type, id
@@ -257,20 +252,25 @@ BlackboardRouter = Backbone.Router.extend
     cb(r) if r? # immediately navigate if method is synchronous
 
   Page: (page, type, id) ->
+    old_room = Session.get 'room_name'
+    new_room = "#{type}/#{id}"
+    if old_room isnt new_room
+      # if switching between a puzzle room and full-screen chat, don't reset limit.
+      Session.set
+        room_name: new_room
+        limit: settings.INITIAL_CHAT_LIMIT
     Session.set
       currentPage: page
       type: type
       id: id
-      room_name: (type+'/'+id)
     # cancel modals if they were active
     $('#nickPickModal').modal 'hide'
     $('#confirmModal').modal 'hide'
 
   urlFor: (type,id) ->
     Meteor._relativeToSiteRootUrl "/#{type}/#{id}"
-  chatUrlFor: (type, id, timestamp) ->
-    (Meteor._relativeToSiteRootUrl "/chat#{this.urlFor(type,id)}") + \
-    (if (+timestamp) then "/#{+timestamp}" else "")
+  chatUrlFor: (type, id) ->
+    (Meteor._relativeToSiteRootUrl "/chat#{this.urlFor(type,id)}")
 
   goTo: (type,id) ->
     this.navigate(this.urlFor(type,id), {trigger:true})
@@ -279,8 +279,8 @@ BlackboardRouter = Backbone.Router.extend
 
   goToPuzzle: (puzzle) ->  this.goTo("puzzles", puzzle._id)
 
-  goToChat: (type, id, timestamp) ->
-    this.navigate(this.chatUrlFor(type, id, timestamp), {trigger:true})
+  goToChat: (type, id) ->
+    this.navigate(this.chatUrlFor(type, id), {trigger:true})
 
 share.Router = new BlackboardRouter()
 Backbone.history.start {pushState: true}

--- a/client/main.coffee
+++ b/client/main.coffee
@@ -132,8 +132,7 @@ Meteor.startup ->
     return if share.notification.count() is 0 # unsubscribes
     p = share.chat.pageForTimestamp 'oplog/0', 0, {subscribe:true}
     return unless p? # wait until page info is loaded
-    messages = if p.archived then "oldmessages" else "messages"
-    Meteor.subscribe "#{messages}-in-range", p.room_name, p.from, p.to,
+    Meteor.subscribe 'messages-in-range', p.room_name, p.from, p.to,
       onStop: -> suppress = true
       onReady: -> suppress = false
   share.model.Messages.find({room_name: 'oplog/0', timestamp: $gte: now}).observeChanges

--- a/client/oplog.coffee
+++ b/client/oplog.coffee
@@ -3,24 +3,11 @@ model = share.model
 chat = share.chat
 
 Template.oplog.helpers
-  prevTimestamp: ->
-    p = chat.pageForTimestamp 'oplog/0', +Session.get('timestamp')
-    return unless p?.from
-    "/oplogs/#{p.from}"
   oplogs: ->
-    p = chat.pageForTimestamp 'oplog/0', +Session.get('timestamp')
-    chat.messagesForPage p,
+    model.Messages.find room_name: 'oplog/0',
       sort: [['timestamp','asc']]
   prettyType: ->
     model.pretty_collection(this.type)
-  nextTimestamp: ->
-    p = chat.pageForTimestamp 'oplog/0', +Session.get('timestamp')
-    return unless p?.next?
-    p = model.Pages.findOne(p.next)
-    return unless p?
-    "/oplogs/#{p.to}"
-  timestamp: ->
-    +Session.get('timestamp')
 
 Template.oplog.onRendered ->
   $("title").text("Operation Log Archive")
@@ -28,12 +15,4 @@ Template.oplog.onRendered ->
 
 Template.oplog.onCreated -> this.autorun =>
   room_name = 'oplog/0'
-  timestamp = +Session.get('timestamp')
-  p = chat.pageForTimestamp room_name, timestamp, {subscribe:this}
-  return unless p? # wait until page info is loaded
-  this.subscribe 'messages-in-range', room_name, p.from, p.to
-  # subscribe to the 'prev' and 'next' pages as well
-  if p.next?
-    this.subscribe 'page-by-id', p.next
-  if p.prev?
-    this.subscribe 'page-by-id', p.prev
+  this.subscribe 'recent-messages', room_name, +Session.get('limit')

--- a/client/oplog.coffee
+++ b/client/oplog.coffee
@@ -31,8 +31,7 @@ Template.oplog.onCreated -> this.autorun =>
   timestamp = +Session.get('timestamp')
   p = chat.pageForTimestamp room_name, timestamp, {subscribe:this}
   return unless p? # wait until page info is loaded
-  messages = if p.archived then "oldmessages" else "messages"
-  this.subscribe "#{messages}-in-range", room_name, p.from, p.to
+  this.subscribe 'messages-in-range', room_name, p.from, p.to
   # subscribe to the 'prev' and 'next' pages as well
   if p.next?
     this.subscribe 'page-by-id', p.next

--- a/lib/methods/correctCallIn.test.coffee
+++ b/lib/methods/correctCallIn.test.coffee
@@ -72,7 +72,7 @@ describe 'correctCallIn', ->
       chai.assert.isUndefined model.CallIns.findOne callin
 
     it 'oplogs', ->
-      o = model.Messages.find(room_name: 'oplog/0').fetch()
+      o = model.Messages.find(room_name: 'oplog/0', dawn_of_time: $ne: true).fetch()
       chai.assert.lengthOf o, 1
       chai.assert.include o[0],
         type: 'puzzles'
@@ -82,7 +82,7 @@ describe 'correctCallIn', ->
       chai.assert.include o[0].body, '(PRECIPITATE)', 'message'
 
     it 'notifies puzzle chat', ->
-      o = model.Messages.find(room_name: "puzzles/#{puzzle}").fetch()
+      o = model.Messages.find(room_name: "puzzles/#{puzzle}", dawn_of_time: $ne: true).fetch()
       chai.assert.lengthOf o, 1
       chai.assert.include o[0],
         nick: 'cjb'
@@ -91,7 +91,7 @@ describe 'correctCallIn', ->
       chai.assert.notInclude o[0].body, '(Foo)', 'message'
 
     it 'notifies general chat', ->
-      o = model.Messages.find(room_name: "general/0").fetch()
+      o = model.Messages.find(room_name: "general/0", dawn_of_time: $ne: true).fetch()
       chai.assert.lengthOf o, 1
       chai.assert.include o[0],
         nick: 'cjb'
@@ -115,7 +115,7 @@ describe 'correctCallIn', ->
       puzzles: [puzzle]
     model.Puzzles.update puzzle, $push: feedsInto: meta
     Meteor.callAs 'correctCallIn', 'cjb', callin
-    m = model.Messages.find(room_name: "puzzles/#{meta}").fetch()
+    m = model.Messages.find(room_name: "puzzles/#{meta}", dawn_of_time: $ne: true).fetch()
     chai.assert.lengthOf m, 1
     chai.assert.include m[0],
       nick: 'cjb'

--- a/lib/methods/incorrectCallIn.test.coffee
+++ b/lib/methods/incorrectCallIn.test.coffee
@@ -66,7 +66,7 @@ describe 'incorrectCallIn', ->
       chai.assert.lengthOf model.Messages.find({type: 'puzzles', id: puzzle, stream: 'callins'}).fetch(), 1
 
     it "notifies puzzle chat", ->
-      chai.assert.lengthOf model.Messages.find(room_name: "puzzles/#{puzzle}").fetch(), 1
+      chai.assert.lengthOf model.Messages.find(room_name: "puzzles/#{puzzle}", dawn_of_time: $ne: true).fetch(), 1
 
     it "notifies general chat", ->
-      chai.assert.lengthOf model.Messages.find(room_name: 'general/0').fetch(), 1
+      chai.assert.lengthOf model.Messages.find(room_name: 'general/0', dawn_of_time: $ne: true).fetch(), 1

--- a/lib/methods/newCallIn.test.coffee
+++ b/lib/methods/newCallIn.test.coffee
@@ -70,7 +70,7 @@ describe 'newCallIn', ->
           provided: false
 
       it 'oplogs', ->
-        o = model.Messages.find(room_name: 'oplog/0').fetch()
+        o = model.Messages.find(room_name: 'oplog/0', dawn_of_time: $ne: true).fetch()
         chai.assert.lengthOf o, 1
         chai.assert.include o[0],
           type: 'puzzles'
@@ -81,7 +81,7 @@ describe 'newCallIn', ->
         chai.assert.include o[0].body, 'precipitate', 'message'
 
       it 'notifies puzzle chat', ->
-        o = model.Messages.find(room_name: "puzzles/#{id}").fetch()
+        o = model.Messages.find(room_name: "puzzles/#{id}", dawn_of_time: $ne: true).fetch()
         chai.assert.lengthOf o, 1
         chai.assert.include o[0],
           nick: 'torgen'
@@ -90,7 +90,7 @@ describe 'newCallIn', ->
         chai.assert.notInclude o[0].body, '(Foo)', 'message'
 
       it 'notifies general chat', ->
-        o = model.Messages.find(room_name: "general/0").fetch()
+        o = model.Messages.find(room_name: "general/0", dawn_of_time: $ne: true).fetch()
         chai.assert.lengthOf o, 1
         chai.assert.include o[0],
           nick: 'torgen'
@@ -164,7 +164,7 @@ describe 'newCallIn', ->
     Meteor.callAs 'newCallIn', 'torgen',
       target: p
       answer: 'precipitate'
-    m = model.Messages.find(room_name: "puzzles/#{meta}").fetch()
+    m = model.Messages.find(room_name: "puzzles/#{meta}", dawn_of_time: $ne: true).fetch()
     chai.assert.lengthOf m, 1
     chai.assert.include m[0],
       nick: 'torgen'

--- a/lib/methods/newPoll.test.coffee
+++ b/lib/methods/newPoll.test.coffee
@@ -69,7 +69,7 @@ describe 'newPoll', ->
   it 'creates message', ->
     Meteor.callAs 'newPoll', 'torgen', 'general/0', 'What up?', ['Red', 'Orange', 'Yellow', 'Green', 'Blue']
     p = model.Polls.findOne()._id
-    chai.assert.deepInclude model.Messages.findOne(),
+    chai.assert.deepInclude model.Messages.findOne(dawn_of_time: $ne: true),
       room_name: 'general/0'
       nick: 'torgen'
       body: 'What up?'

--- a/lib/methods/setStarred.test.coffee
+++ b/lib/methods/setStarred.test.coffee
@@ -22,38 +22,36 @@ describe 'setStarred', ->
   beforeEach ->
     resetDatabase()
 
-  ['messages', 'oldmessages'].forEach (collection) =>
-    describe "in #{collection}", ->
-      [null, true].forEach (was_starred) =>
-        describe "starred was #{was_starred}", ->
-          [false, true].forEach (set_starred) =>
-            describe "set to #{set_starred}", ->
-              id = null
-              beforeEach ->
-                id = model.collection(collection).insert
-                  nick: 'torgen'
-                  body: 'nobody star this'
-                  timestamp: 5
-                  room_name: 'general/0'
-                  starred: was_starred
-              it 'fails without login', ->
-                chai.assert.throws ->
-                  Meteor.call 'setStarred', id, set_starred
-                , Match.Error
-              describe 'when logged in', ->
-                it 'succeeds', ->
-                  Meteor.callAs 'setStarred', 'cjb', id, set_starred
-                  chai.assert.include model.collection(collection).findOne(id),
-                    starred: set_starred or null
-      it 'fails on unstarrable', ->
-        id = model.collection(collection).insert
-          nick: 'torgen'
-          body: 'won\'t let you star this'
-          action: true
-          timestamp: 5
-          room_name: 'general/0'
-        Meteor.callAs 'setStarred', 'cjb', id, true
-        chai.assert.notInclude model.collection(collection).findOne(id),
-          starred: null
+  [null, true].forEach (was_starred) =>
+    describe "starred was #{was_starred}", ->
+      [false, true].forEach (set_starred) =>
+        describe "set to #{set_starred}", ->
+          id = null
+          beforeEach ->
+            id = model.Messages.insert
+              nick: 'torgen'
+              body: 'nobody star this'
+              timestamp: 5
+              room_name: 'general/0'
+              starred: was_starred
+          it 'fails without login', ->
+            chai.assert.throws ->
+              Meteor.call 'setStarred', id, set_starred
+            , Match.Error
+          describe 'when logged in', ->
+            it 'succeeds', ->
+              Meteor.callAs 'setStarred', 'cjb', id, set_starred
+              chai.assert.include model.Messages.findOne(id),
+                starred: set_starred or null
+  it 'fails on unstarrable', ->
+    id = model.Messages.insert
+      nick: 'torgen'
+      body: 'won\'t let you star this'
+      action: true
+      timestamp: 5
+      room_name: 'general/0'
+    Meteor.callAs 'setStarred', 'cjb', id, true
+    chai.assert.notInclude model.Messages.findOne(id),
+      starred: null
             
           

--- a/lib/methods/summon.test.coffee
+++ b/lib/methods/summon.test.coffee
@@ -114,13 +114,13 @@ describe 'summon', ->
         tags: status: {name: 'Status', value: 'Stuck like glue', touched: 7, touched_by: 'torgen'}
 
     it 'notifies main chat', ->
-      msgs = model.Messages.find(room_name: 'general/0').fetch()
+      msgs = model.Messages.find(room_name: 'general/0', dawn_of_time: $ne: true).fetch()
       chai.assert.lengthOf msgs, 1
       chai.assert.include msgs[0].body, ': Stuck like glue ('
       chai.assert.include msgs[0].body, 'Foo'
 
     it "notifies puzzle chat", ->
-      msgs = model.Messages.find(room_name: "puzzles/#{id}").fetch()
+      msgs = model.Messages.find(room_name: "puzzles/#{id}", dawn_of_time: $ne: true).fetch()
       chai.assert.lengthOf msgs, 1
       chai.assert.include msgs[0].body, ': Stuck like glue'
       chai.assert.notInclude msgs[0].body, 'Foo'
@@ -162,13 +162,13 @@ describe 'summon', ->
           tags: status: {name: 'Status', value: 'Stuck', touched: 7, touched_by: 'torgen'}
 
       it 'notifies main chat', ->
-        msgs = model.Messages.find(room_name: 'general/0').fetch()
+        msgs = model.Messages.find(room_name: 'general/0', dawn_of_time: $ne: true).fetch()
         chai.assert.lengthOf msgs, 1
         chai.assert.include msgs[0].body, ': Stuck ('
         chai.assert.include msgs[0].body, 'Foo'
 
       it "notifies puzzle chat", ->
-        msgs = model.Messages.find(room_name: "puzzles/#{id}").fetch()
+        msgs = model.Messages.find(room_name: "puzzles/#{id}", dawn_of_time: $ne: true).fetch()
         chai.assert.lengthOf msgs, 1
         chai.assert.include msgs[0].body, ': Stuck'
         chai.assert.notInclude msgs[0].body, 'Foo'
@@ -193,13 +193,13 @@ describe 'summon', ->
           tags: status: {name: 'Status', value: 'stucK like glue', touched: 7, touched_by: 'torgen'}
 
       it 'notifies main chat', ->
-        msgs = model.Messages.find(room_name: 'general/0').fetch()
+        msgs = model.Messages.find(room_name: 'general/0', dawn_of_time: $ne: true).fetch()
         chai.assert.lengthOf msgs, 1
         chai.assert.include msgs[0].body, ': stucK like glue ('
         chai.assert.include msgs[0].body, 'Foo'
 
       it "notifies puzzle chat", ->
-        msgs = model.Messages.find(room_name: "puzzles/#{id}").fetch()
+        msgs = model.Messages.find(room_name: "puzzles/#{id}", dawn_of_time: $ne: true).fetch()
         chai.assert.lengthOf msgs, 1
         chai.assert.include msgs[0].body, ': stucK like glue'
         chai.assert.notInclude msgs[0].body, 'Foo'
@@ -224,14 +224,14 @@ describe 'summon', ->
           tags: status: {name: 'Status', value: 'Stuck: no idea', touched: 7, touched_by: 'torgen'}
 
       it 'notifies main chat', ->
-        msgs = model.Messages.find(room_name: 'general/0').fetch()
+        msgs = model.Messages.find(room_name: 'general/0', dawn_of_time: $ne: true).fetch()
         chai.assert.lengthOf msgs, 1
         chai.assert.include msgs[0].body, ': no idea ('
         chai.assert.notInclude msgs[0].body, 'Stuck'
         chai.assert.include msgs[0].body, 'Foo'
 
       it "notifies puzzle chat", ->
-        msgs = model.Messages.find(room_name: "puzzles/#{id}").fetch()
+        msgs = model.Messages.find(room_name: "puzzles/#{id}", dawn_of_time: $ne: true).fetch()
         chai.assert.lengthOf msgs, 1
         chai.assert.include msgs[0].body, ': no idea'
         chai.assert.notInclude msgs[0].body, 'Stuck'

--- a/lib/methods/unsummon.test.coffee
+++ b/lib/methods/unsummon.test.coffee
@@ -90,13 +90,13 @@ describe 'unsummon', ->
         chai.assert.lengthOf model.Messages.find({room_name: 'oplog/0', type: 'puzzles', id: id}).fetch(), 1
 
       it 'notifies main chat', ->
-        msgs = model.Messages.find(room_name: 'general/0').fetch()
+        msgs = model.Messages.find(room_name: 'general/0', dawn_of_time: $ne: true).fetch()
         chai.assert.lengthOf msgs, 1
         chai.assert.include msgs[0].body, 'has arrived'
         chai.assert.include msgs[0].body, "puzzle Foo"
 
       it "notifies puzzle chat", ->
-        msgs = model.Messages.find(room_name: "puzzles/#{id}").fetch()
+        msgs = model.Messages.find(room_name: "puzzles/#{id}", dawn_of_time: $ne: true).fetch()
         chai.assert.lengthOf msgs, 1
         chai.assert.include msgs[0].body, 'has arrived'
         chai.assert.notInclude msgs[0].body, "puzzle Foo"
@@ -130,13 +130,13 @@ describe 'unsummon', ->
       chai.assert.lengthOf model.Messages.find({room_name: 'oplog/0', type: 'puzzles', id: id}).fetch(), 1
 
     it 'notifies main chat', ->
-      msgs = model.Messages.find(room_name: 'general/0').fetch()
+      msgs = model.Messages.find(room_name: 'general/0', dawn_of_time: $ne: true).fetch()
       chai.assert.lengthOf msgs, 1
       chai.assert.include msgs[0].body, 'no longer'
       chai.assert.include msgs[0].body, "puzzle Foo"
 
     it "notifies puzzle chat", ->
-      msgs = model.Messages.find(room_name: "puzzles/#{id}").fetch()
+      msgs = model.Messages.find(room_name: "puzzles/#{id}", dawn_of_time: $ne: true).fetch()
       chai.assert.lengthOf msgs, 1
       chai.assert.include msgs[0].body, 'no longer'
       chai.assert.notInclude msgs[0].body, "puzzle Foo"

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -449,6 +449,7 @@ doc_id_to_link = (id) ->
         sort_key: UTCNow()
       ensureDawnOfTime "rounds/#{r._id}"
       # TODO(torgen): create default meta
+      r
     renameRound: (args) ->
       check @userId, NonEmptyString
       renameObject "rounds", {args..., who: @userId}

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -106,23 +106,17 @@ Meteor.publish 'page-by-id', loginRequired (id) -> model.Pages.find _id: id
 Meteor.publish 'page-by-timestamp', loginRequired (room_name, timestamp) ->
   model.Pages.find room_name: room_name, to: timestamp
 
-for messages in [ 'messages', 'oldmessages' ]
-  do (messages) ->
-    # paged messages.  client is responsible for giving a reasonable
-    # range, which is a bit of an issue.  Once limit is supported in oplog
-    # we could probably add a limit here to be a little safer.
-    Meteor.publish "#{messages}-in-range", loginRequired (room_name, from, to=0) ->
-      cond = $gte: +from, $lt: +to
-      delete cond.$lt if cond.$lt is 0
-      model.collection(messages).find
-        room_name: room_name
-        timestamp: cond
-        $or: [ {to: $in: [null, @userId]}, {nick: @userId }]
+Meteor.publish 'messages-in-range', loginRequired (room_name, from, to=0) ->
+  cond = $gte: +from, $lt: +to
+  delete cond.$lt if cond.$lt is 0
+  model.Messages.find
+    room_name: room_name
+    timestamp: cond
+    $or: [ {to: $in: [null, @userId]}, {nick: @userId }]
 
 Meteor.publish 'starred-messages', loginRequired (room_name) ->
-  for messages in [ model.OldMessages, model.Messages ]
-    messages.find { room_name: room_name, starred: true },
-      sort: [["timestamp", "asc"]]
+  model.Messages.find { room_name: room_name, starred: true },
+    sort: [["timestamp", "asc"]]
 
 Meteor.publish 'callins', loginRequired ->
   model.CallIns.find {},

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -123,8 +123,6 @@ Meteor.publish 'oplogs-since', loginRequired (since) ->
   model.Messages.find
     room_name: 'oplog/0'
     timestamp: $gt: since
-  ,
-    sort: [['timestamp', 'desc']]
 
 Meteor.publish 'starred-messages', loginRequired (room_name) ->
   model.Messages.find { room_name: room_name, starred: true },

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -112,7 +112,7 @@ Meteor.publish 'recent-header-messages', loginRequired ->
   model.Messages.find
     room_name: 'general/0'
     system: $ne: true
-    body_is_html: $ne: true
+    bodyIsHtml: $ne: true
     $or: [ {to: null}, {to: @userId}, {nick: @userId }]
   ,
     sort: [['timestamp', 'desc']]


### PR DESCRIPTION
There's now a single messages collection with all the messages in it. I'm confident any performance issues that caused in the past are fixed by better indexing, and by being able to apply a limit to the cursor you return from a publish. There's still a button to load history, but it adds it to the current view instead of viewing just the history page. I haven't added continuous scrolling, but this will make it possible.