### PR TITLE
Include all server code in coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_install:
   - curl https://install.meteor.com | /bin/sh
 
 script:
-  - COVERAGE=1 COVERAGE_APP_FOLDER=$PWD/ COVERAGE_OUT_COVERASE=1 ~/.meteor/meteor npm test
-  - COVERAGE=1 COVERAGE_APP_FOLDER=$PWD/ COVERAGE_IN_COVERASE=1 COVERAGE_OUT_LCOVONLY=1  ~/.meteor/meteor npm run-script test.full
+  - COVERAGE=1 COVERAGE_APP_FOLDER=$PWD/ COVERAGE_OUT_COVERAGE=1 ~/.meteor/meteor npm test
+  - COVERAGE=1 COVERAGE_APP_FOLDER=$PWD/ COVERAGE_IN_COVERAGE=1 COVERAGE_OUT_LCOVONLY=1  ~/.meteor/meteor npm run-script test.full
 
 after_success:
   - cat .coverage/lcov.info | node_modules/coveralls/bin/coveralls.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ language: node_js
 node_js:
  - 8
 
+env:
+  global:
+    - COVERALLS_PARALLEL=true
+
+  matrix:
+    - TEST_SCRIPT=coverage.lcov
+    - TEST_SCRIPT=coverage.full.lcov
+
 cache:
   directories:
     - node_modules
@@ -11,8 +19,10 @@ before_install:
   - curl https://install.meteor.com | /bin/sh
 
 script:
-  - COVERAGE=1 COVERAGE_APP_FOLDER=$PWD/ COVERAGE_OUT_COVERAGE=1 ~/.meteor/meteor npm test
-  - COVERAGE=1 COVERAGE_APP_FOLDER=$PWD/ COVERAGE_IN_COVERAGE=1 COVERAGE_OUT_LCOVONLY=1  ~/.meteor/meteor npm run-script test.full
+  - ~/.meteor/meteor npm run-script $TEST_SCRIPT
 
 after_success:
   - cat .coverage/lcov.info | node_modules/coveralls/bin/coveralls.js
+
+notifications:
+  webhooks: https://coveralls.io/webhook

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ before_install:
   - curl https://install.meteor.com | /bin/sh
 
 script:
-  - ~/.meteor/meteor npm run-script coverage.lcov
+  - COVERAGE=1 COVERAGE_APP_FOLDER=$PWD/ COVERAGE_OUT_COVERASE=1 ~/.meteor/meteor npm test
+  - COVERAGE=1 COVERAGE_APP_FOLDER=$PWD/ COVERAGE_IN_COVERASE=1 COVERAGE_OUT_LCOVONLY=1  ~/.meteor/meteor npm run-script test.full
 
 after_success:
   - cat .coverage/lcov.info | node_modules/coveralls/bin/coveralls.js

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test": "meteor test --once --driver-package meteortesting:mocha",
     "test.full": "meteor test --once --driver-package meteortesting:mocha --full-app",
     "coverage": "COVERAGE=1 COVERAGE_OUT_HTML=1 COVERAGE_APP_FOLDER=$PWD/ meteor npm test",
-    "coverage.lcov": "COVERAGE=1 COVERAGE_OUT_LCOVONLY=1 COVERAGE_APP_FOLDER=$PWD/ meteor npm test"
+    "coverage.lcov": "COVERAGE=1 COVERAGE_OUT_LCOVONLY=1 COVERAGE_APP_FOLDER=$PWD/ meteor npm test",
+    "coverage.full.lcov": "COVERAGE=1 COVERAGE_OUT_LCOVONLY=1 COVERAGE_APP_FOLDER=$PWD/ meteor npm run-script test.full"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "test": "meteor test --once --driver-package meteortesting:mocha",
+    "test.full": "meteor test --once --driver-package meteortesting:mocha --full-app",
     "coverage": "COVERAGE=1 COVERAGE_OUT_HTML=1 COVERAGE_APP_FOLDER=$PWD/ meteor npm test",
     "coverage.lcov": "COVERAGE=1 COVERAGE_OUT_LCOVONLY=1 COVERAGE_APP_FOLDER=$PWD/ meteor npm test"
   },

--- a/server/bootstrap.coffee
+++ b/server/bootstrap.coffee
@@ -45,7 +45,7 @@ Meteor.startup ->
     # add some general chats
     for chat in SAMPLE_CHATS
       chat.room_name = "general/0"
-      callAs "newMessage", chat.nick, chat
+      callAs "newMessage", chat.nick, {body: chat.body}
     # add some user ids
     for nick in SAMPLE_NICKS
       Meteor.users.insert nick

--- a/server/drive.coffee
+++ b/server/drive.coffee
@@ -18,6 +18,9 @@ EMAIL = Meteor.settings.email or '571639156428@developer.gserviceaccount.com'
 SCOPES = ['https://www.googleapis.com/auth/drive']
 
 # Intialize APIs and load rootFolder
+if Meteor.isAppTest
+  share.drive = new FailDrive
+  return
 Promise.await do ->
   try
     auth = null


### PR DESCRIPTION
Run parallel builds of the unit tests and a 'full app' test so our coverage report includes all the server-side code. Also tests the bootstrap data loading, as requested in #115.