### PR TITLE
Make puzzles queries use oplog driver

### DIFF
--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -169,7 +169,7 @@ Template.blackboard.helpers
   unassigned: unassigned_helper
   favorites: ->
     query = $or: [
-      {favorites: Meteor.userId()},
+      {"favorites.#{Meteor.userId()}": true},
       mechanics: $in: Meteor.user().favorite_mechanics or []
     ]
     if not Session.get('canEdit') and 'true' is reactiveLocalStorage.getItem 'hideSolved'

--- a/client/favorite.coffee
+++ b/client/favorite.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
 Template.favorite.helpers
-  favorite: -> @favorites?.includes Meteor.userId()
+  favorite: -> @favorites?[Meteor.userId()]
 
 Template.favorite.events
   'click .favorite': (event, template) -> Meteor.call 'unfavorite', @_id

--- a/lib/methods/favorite.test.coffee
+++ b/lib/methods/favorite.test.coffee
@@ -70,7 +70,8 @@ describe 'favorite', ->
         chai.assert.isTrue ret
 
       it 'sets favorites', ->
-        chai.assert.deepEqual model.Puzzles.findOne(id).favorites, ['cjb']
+        chai.assert.deepEqual model.Puzzles.findOne(id).favorites,
+          cjb: true
 
       it 'does not touch', ->
         doc = model.Puzzles.findOne id
@@ -90,7 +91,9 @@ describe 'favorite', ->
         solved: null
         solved_by: null
         incorrectAnswers: []
-        favorites: ['torgen', 'cscott']
+        favorites:
+          torgen: true
+          cscott: true
         link: 'https://puzzlehunt.mit.edu/foo'
         drive: 'fid'
         spreadsheet: 'sid'
@@ -111,7 +114,10 @@ describe 'favorite', ->
         chai.assert.isTrue ret
 
       it 'sets favorites', ->
-        chai.assert.deepEqual model.Puzzles.findOne(id).favorites, ['torgen', 'cscott', 'cjb']
+        chai.assert.deepEqual model.Puzzles.findOne(id).favorites,
+          torgen: true
+          cscott: true
+          cjb: true
 
       it 'does not touch', ->
         doc = model.Puzzles.findOne id
@@ -131,7 +137,9 @@ describe 'favorite', ->
         solved: null
         solved_by: null
         incorrectAnswers: []
-        favorites: ['torgen', 'cjb']
+        favorites:
+          torgen: true
+          cjb: true
         link: 'https://puzzlehunt.mit.edu/foo'
         drive: 'fid'
         spreadsheet: 'sid'
@@ -152,7 +160,9 @@ describe 'favorite', ->
         chai.assert.isTrue ret
 
       it 'leaves favorites unchanged', ->
-        chai.assert.deepEqual model.Puzzles.findOne(id).favorites, ['torgen', 'cjb']
+        chai.assert.deepEqual model.Puzzles.findOne(id).favorites,
+          torgen: true
+          cjb: true
 
       it 'does not touch', ->
         doc = model.Puzzles.findOne id

--- a/lib/methods/unfavorite.test.coffee
+++ b/lib/methods/unfavorite.test.coffee
@@ -90,7 +90,9 @@ describe 'unfavorite', ->
         solved: null
         solved_by: null
         incorrectAnswers: []
-        favorites: ['torgen', 'cscott']
+        favorites:
+          torgen: true
+          cscott: true
         link: 'https://puzzlehunt.mit.edu/foo'
         drive: 'fid'
         spreadsheet: 'sid'
@@ -111,7 +113,9 @@ describe 'unfavorite', ->
         chai.assert.isTrue ret
 
       it 'leaves favorites unchanged', ->
-        chai.assert.deepEqual model.Puzzles.findOne(id).favorites, ['torgen', 'cscott']
+        chai.assert.deepEqual model.Puzzles.findOne(id).favorites,
+          torgen: true
+          cscott: true
 
       it 'does not touch', ->
         doc = model.Puzzles.findOne id
@@ -131,7 +135,9 @@ describe 'unfavorite', ->
         solved: null
         solved_by: null
         incorrectAnswers: []
-        favorites: ['torgen', 'cjb']
+        favorites:
+          torgen: true
+          cjb: true
         link: 'https://puzzlehunt.mit.edu/foo'
         drive: 'fid'
         spreadsheet: 'sid'
@@ -152,7 +158,8 @@ describe 'unfavorite', ->
         chai.assert.isTrue ret
 
       it 'removes self from favorites', ->
-        chai.assert.deepEqual model.Puzzles.findOne(id).favorites, ['torgen']
+        chai.assert.deepEqual model.Puzzles.findOne(id).favorites,
+          torgen: true
 
       it 'does not touch', ->
         doc = model.Puzzles.findOne id

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -89,8 +89,9 @@ if Meteor.isServer
 #   drive: optional google drive folder id
 #   spreadsheet: optional google spreadsheet id
 #   doc: optional google doc id
-#   favorites: list of userids of users who favorited this puzzle.
-#              on the client, either empty/null or contains only you.
+#   favorites: object whose keys are userids of users who favorited this
+#              puzzle. Values are true. On the client, either empty or contains
+#              only you.
 #   mechanics: list of canonical forms of mechanic names from
 #              ./imports/mechanics.coffee.
 #   puzzles: array of puzzle _ids for puzzles that feed into this.
@@ -1200,15 +1201,15 @@ doc_id_to_link = (id) ->
     favorite: (puzzle) ->
       check @userId, NonEmptyString
       check puzzle, NonEmptyString
-      num = Puzzles.update puzzle, $addToSet:
-        favorites: @userId
+      num = Puzzles.update puzzle, $set:
+        "favorites.#{@userId}": true
       num > 0
 
     unfavorite: (puzzle) ->
       check @userId, NonEmptyString
       check puzzle, NonEmptyString
-      num = Puzzles.update puzzle, $pull:
-        favorites: @userId
+      num = Puzzles.update puzzle, $unset:
+        "favorites.#{@userId}": ''
       num > 0
 
     addMechanic: (puzzle, mechanic) ->

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -19,7 +19,7 @@ puzzleQuery = (query) ->
       drive: 1
       spreadsheet: 1
       doc: 1
-      favorites: $elemMatch: $eq: @userId
+      "favorites.#{@userId}": 1
       mechanics: 1
       puzzles: 1
       feedsInto: 1


### PR DESCRIPTION
Changes the set of users who've favorited a puzzle to a sub-document, so that filtering it to just the current user can be done with the oplog observe driver instead of having to use the polling driver like the $elemMatch version did.
Fixes #138