### PR TITLE
Fullscreen

### DIFF
--- a/blackboard.less
+++ b/blackboard.less
@@ -157,7 +157,6 @@ body.has-emojis {
 
 #bb-body {
   padding-top: @navbar-height;
-  padding-bottom: 15px;
   &.compactHeader { padding-top: @navbar-height - 40px; }
 }
 
@@ -314,7 +313,7 @@ input[type=color] {
 #bb-tables {
   background: white;
   margin-top: 10px;
-  padding-bottom: 15px;
+  padding-bottom: 30px;
   padding-left: 15px;
   padding-right: 15px;
   -webkit-border-radius: 6px;
@@ -559,11 +558,14 @@ input[type=color] {
     padding: 0;
     .navbar-inner { padding: 0px; }
   }
-  .container-fluid > .navbar-fixed-top {
+  #bb-content > .navbar-fixed-top {
     position: absolute;
   }
   #messages {
     padding-top: @navbar-height - 20px;
+    .compactHeader & {
+      padding-top: 22px;
+    }
     /* Need this amount of specificity to override .row-fluid rule. */
     #bb-body .bb-splitter & { padding-top: 0px; }
   }
@@ -574,12 +576,6 @@ input[type=color] {
     padding-bottom: 0;
     #bb-content > #bb-blackboard {
       padding-top: @navbar-height - 40px;
-    }
-  }
-  #bb-tables {
-    section {
-      padding-top: 0;
-      margin-top: 0;
     }
   }
   .bb-hide-status {

--- a/chat.less
+++ b/chat.less
@@ -24,7 +24,7 @@
   }
 }
 .compactHeader .bb-chat-messages {
-  padding-top: 3px;
+  padding-top: 20px;
 }
 .bb-chat-messages {
   @chat-arrow-size: 6px;
@@ -197,8 +197,6 @@
     line-height: 8px;
     margin-top: -8px;
     padding-left: 1px;
-    /* compensate for 20px of padding on container-fluid */
-    margin-left: -20px; margin-right: -20px;
   }
   .bb-quip-action {
     &:before {

--- a/client/main.coffee
+++ b/client/main.coffee
@@ -61,6 +61,8 @@ Template.registerHelper 'plural', (x) -> x != 1
 
 Template.registerHelper 'nullToZero', (x) -> x ? 0
 
+Template.registerHelper 'canGoFullScreen', -> $('body').get(0)?.requestFullscreen?
+
 # subscribe to the all-names feed all the time
 Meteor.subscribe 'all-names'
 # subscribe to all nicks all the time

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -72,6 +72,9 @@ Template.puzzle.helpers
   color: -> color @puzzle if @puzzle
   docLoaded: -> Template.instance().docLoaded.get()
 
+Template.puzzle.events 
+  'click .bb-go-fullscreen': (e, t) -> $('.bb-puzzleround').get(0)?.requestFullscreen navigationUI: 'hide'
+
 Template.header_breadcrumb_extra_links.helpers
   currentViewIs: (view) -> currentViewIs this, view
 

--- a/header.html
+++ b/header.html
@@ -278,7 +278,7 @@
          title="Complete {{roomname}} chat">more...</a><br/>
       <a href="/chat/general/0" class="chat-link bb-pop-out"
          title="Pop out {{roomname}} chat"
-         target="chat0">pop out <i class="fas fa-expand-arrows-alt"></i></a>
+         target="chat0">pop out <i class="fas fa-external-link-alt"></i></a>
     </div>
     <span class="left pull-left label label-inverse">
       {{roomname}}:

--- a/page.html
+++ b/page.html
@@ -33,7 +33,7 @@ function onGoogleApiLoad() {
 </body>
 
 <template name="page">
-<div id="bb-content" class="container-fluid">
+<div id="bb-content">
 <!-- DEBUGGING: currentPage: "{{currentPage}}" -->
 
 <!-- common header -->

--- a/puzzle.html
+++ b/puzzle.html
@@ -57,12 +57,25 @@
 <div class="row-fluid bb-puzzleround" style="{{#unless boringMode}}background: {{color}}{{/unless}}">
  <!-- this is a puzzle page -->
 {{#horizontal_splitter}}
+  <div class="bb-pop-full-menu">
+    {{#if currentViewIs "spreadsheet"}}
+      {{#if puzzle.spreadsheet}}
+        <a href="{{spread_link puzzle.spreadsheet}}" target="_blank" title="Open spreadsheet in new window"><i class='fas fa-external-link-alt'></i></a>
+      {{/if}}
+    {{else if currentViewIs "doc"}}
+      {{#if puzzle.doc}}
+        <a href="{{doc_link puzzle.doc}}" target="_blank" title="Open document in new window"><i class='fas fa-external-link-alt'></i></a>
+      {{/if}}
+    {{else if currentViewIs "puzzle"}}
+      {{#if puzzle.link}}
+        <a href="{{puzzle.link}}" target="_blank" title="Open puzzle in new window"><i class='fas fa-external-link-alt'></i></a>
+      {{/if}}
+    {{/if}}
+    {{#if canGoFullScreen}}
+      <a href="#" class="bb-go-fullscreen" title="Full screen"><i class='fas fa-expand-arrows-alt'></i></a>
+    {{/if}}
+  </div>
   {{#if puzzle.spreadsheet}}
-    <div class="bb-left-header" style="{{#unless currentViewIs "spreadsheet"}}display: none;{{/unless}}">
-      <a align="center" href="{{spread_link puzzle.spreadsheet}}"
-         target="_blank"><i class='fas fa-expand-arrows-alt'></i>
-      Open spreadsheet in new window</a>
-    </div>
     {{! hide iframe when not current view for faster tab change }}
     <iframe class="bb-spreadsheet-frame" frameborder='0' src='{{spread_link puzzle.spreadsheet}}?widget=true&chrome=false&rm=embedded'
             style="{{#unless currentViewIs "spreadsheet"}}display:none{{/unless}}"></iframe>
@@ -73,22 +86,12 @@
         Spreadsheets don't seem to have the same bug, so we can load them
         eagerly.}}
     {{#if docLoaded}}
-      <div class="bb-left-header" style="{{#unless currentViewIs "doc"}}display: none;{{/unless}}">
-        <a align="center" href="{{doc_link puzzle.doc}}"
-          target="_blank"><i class='fas fa-expand-arrows-alt'></i>
-        Open document in new window</a>
-      </div>
       {{! hide iframe when not current view for faster tab change }}
       <iframe class="bb-spreadsheet-frame" frameborder='0' src='{{doc_link puzzle.doc}}?widget=true&chrome=false&rm=embedded'
               style="{{#unless currentViewIs "doc"}}display:none{{/unless}}"></iframe>
     {{/if}}
   {{/if}}
   {{#if embeddable puzzle.link}}
-    <div class="bb-left-header" style="{{#unless currentViewIs "puzzle"}}display: none;{{/unless}}">
-      <a align="center" href="{{puzzle.link}}"
-        target="_blank"><i class='fas fa-expand-arrows-alt'></i>
-      Open puzzle in new window</a>
-    </div>
     {{! hide iframe when not current view for faster tab change }}
     <iframe class="bb-puzzle-frame" frameborder='0' src='{{puzzle.link}}'
             style="{{#unless currentViewIs "puzzle"}}display:none;{{/unless}}"></iframe>
@@ -102,7 +105,7 @@
   {{> embedded_chat}}
   <div class="bb-chat-pop-out {{#if currentViewIs "info"}}in-margin{{/if}}">
     <a href="/chat/puzzles/{{puzzle._id}}" class="chat-link bb-pop-out"
-        target="chat{{puzzle._id}}"><i class="fas fa-expand-arrows-alt"></i>
+        target="chat{{puzzle._id}}"><i class="fas fa-external-link-alt"></i>
   Pop out</a>
   </div>
 {{/horizontal_splitter}}

--- a/splitter.less
+++ b/splitter.less
@@ -4,6 +4,10 @@
           box-sizing: border-box;
 }
 
+:fullscreen .bb-pop-full-menu {
+  display:none;
+}
+
 /* special hack for 100% height layout w/ vertical slider,
    used on puzzle and round pages */
 html.fullHeight {
@@ -54,6 +58,18 @@ html.fullHeight {
       & > .bb-left-content { 
         overflow-y: auto;
         left: 0; top: 0;
+        .bb-pop-full-menu {
+          &:empty {
+            display: none;
+          }
+          position: absolute;
+          right: var(--right-column);
+          margin-right: 6px;
+          background: white;
+          border: 1px solid #888;
+          padding-left: 2px; padding-right: 4px;
+          padding-top: 5px;
+        }
         .bb-left-header {
           position: absolute; right: 100%; writing-mode: vertical-lr; top:10px;
         }


### PR DESCRIPTION
Allow expanding the splitter view on puzzle pages to fullscreen without the header. Also moves the "open in new tab" link out of the margin, which allowed eliminating the margin and gaining 40px of horizontal and 20px of vertical space.
Fixes #148.