### PR TITLE
Keep callins

### DIFF
--- a/blackboard.less
+++ b/blackboard.less
@@ -145,6 +145,11 @@ body.has-emojis {
       font-size: 10.5px;
       padding: 0 6px;
     }
+    td.bb-callin-metadata {
+      white-space: nowrap;
+      text-align: right;
+      border-left: none;
+    }
   }
 }
 .bb-chat-messages {

--- a/callins.html
+++ b/callins.html
@@ -52,13 +52,9 @@
     {{/if}}{{#if solved}}<div class="dupe">Already Solved</div>{{/if}}</td>
     <td><div id="answer-{{_id}}" class="answer">{{answer}}</div>{{#if backsolve}}(backsolve){{/if}}{{#if provided}}(provided){{/if}}
       {{#if alreadyTried}}<div class="dupe">Already Tried</div>{{/if}}
-      {{#if callinTypeIs "interaction request"}}
-        <div class="interaction">Interaction Request</div>
-      {{else if callinTypeIs "message to hq"}}
-        <div class="interaction">Message to HQ</div>
-      {{else if callinTypeIs "expected callback"}}
-        <div class="interaction">Expected Callback</div>
-      {{/if}}
+      {{#unless callinTypeIs "answer"}}
+        <div class="interaction">{{callinType callin_type}}</div>
+      {{/unless}}
       {{#unless callinTypeIs "expected callback"}}
         {{#if hunt_link}}
           <a href="{{hunt_link}}" target="_blank" class="copy-and-go btn btn-info btn-mini" data-clipboard-target="#answer-{{_id}}" title="copy, mark submitted, and go">
@@ -75,30 +71,40 @@
       <input type="checkbox" class="bb-submitted-to-hq" checked={{submitted_to_hq}}>{{#with submitted_by}} by {{gravatar id=nickEmail image="wavatar" size=20 title=(nickOrName this)}}{{/with}}
       {{/if}}
     </td>
-    <td class="form-inline">
-      {{#if allowsResponse}}
-        <div class="input-append">
-          <input type="text" class="response" placeholder="Response from HQ">
-          <button class="btn btn-success bb-callin-correct" title="Correct"><i class="fas fa-check"></i></button>
-          {{#if allowsIncorrect}}
-            <button class="btn btn-danger bb-callin-incorrect" title="Incorrect"><i class="fas fa-times"></i></button>
-          {{/if}}
-        </div>
-        <button class="btn btn-warning bb-callin-cancel" title="Cancel"><i class="fas fa-trash"></i></button>
-      {{else}}
-        <div class="btn-group">
-          <button class="btn btn-success bb-callin-correct">Correct</button>
-          {{#if allowsIncorrect}}
-            <button class="btn btn-danger bb-callin-incorrect">Incorrect</button>
-          {{/if}}
-          <button class="btn btn-warning bb-callin-cancel">Cancel</button>
-        </div>
-      {{/if}}
-    </td>
+    {{> callin_resolution_buttons callin=this}}
     {{else}}
     <td class="text-warning">Log in to resolve answers in queue.</td>
     {{/if}}
   </tr>
+</template>
+
+<template name="callin_resolution_buttons">
+  {{#if allowsResponse}}
+    <div class="bb-callin-allows-response">
+      <div class="input-append">
+        <input type="text" class="response{{#if compact}} input-compact{{/if}}" placeholder="Response{{#unless compact}} from HQ{{/unless}}">
+        <button class="btn btn-success bb-callin-correct{{#if compact}} btn-mini{{/if}}" title="{{accept_message}}"><i class="fas fa-check"></i></button>
+        {{#if allowsIncorrect}}
+          <button class="btn btn-danger bb-callin-incorrect{{#if compact}} btn-mini{{/if}}" title="{{reject_message}}"><i class="fas fa-times"></i></button>
+        {{/if}}
+      </div>
+      <button class="btn btn-warning bb-callin-cancel{{#if compact}} btn-mini{{/if}}" title="{{cancel_message}}"><i class="fas fa-trash"></i></button>
+    </div>
+  {{else}}
+    <div class="btn-group">
+      <button class="btn btn-success bb-callin-correct{{#if compact}} btn-mini{{/if}}" title="{{#if compact}}{{accept_message}}{{/if}}">
+        {{#if compact}}<i class="fas fa-check"></i>{{else}}{{accept_message}}{{/if}}
+      </button>
+      {{#if allowsIncorrect}}
+        <button class="btn btn-danger bb-callin-incorrect{{#if compact}} btn-mini{{/if}}" title="{{#if compact}}{{reject_message}}{{/if}}">
+          {{#if compact}}<i class="fas fa-times"></i>{{else}}{{reject_message}}{{/if}}
+        </button>
+      {{/if}}
+      <button class="btn btn-warning bb-callin-cancel{{#if compact}} btn-mini{{/if}}" title="{{#if compact}}{{cancel_message}}{{/if}}">
+        {{#if compact}}<i class="fas fa-trash"></i>{{else}}{{cancel_message}}{{/if}}
+      </button>
+    </div>
+  {{/if}}
 </template>
 
 <template name="callins_quip">

--- a/callins.html
+++ b/callins.html
@@ -66,12 +66,14 @@
     <td>{{pretty_ts this.created}}</td>
     <td>{{#with lastAttempt}}{{pretty_ts timestamp}} <small>({{pretty_ts timestamp=timestamp style="brief duration"}})</small>{{else}}-{{/with}}</td>
     {{#if mynick}}
-    <td>
-      {{#if callinTypeIs "expected callback"}}N/A{{else}}
-      <input type="checkbox" class="bb-submitted-to-hq" checked={{submitted_to_hq}}>{{#with submitted_by}} by {{gravatar id=nickEmail image="wavatar" size=20 title=(nickOrName this)}}{{/with}}
-      {{/if}}
-    </td>
-    {{> callin_resolution_buttons callin=this}}
+      <td>
+        {{#if callinTypeIs "expected callback"}}N/A{{else}}
+        <input type="checkbox" class="bb-submitted-to-hq" checked={{submitted_to_hq}}>{{#with submitted_by}} by {{gravatar id=nickEmail image="wavatar" size=20 title=(nickOrName this)}}{{/with}}
+        {{/if}}
+      </td>
+      <td class="form-inline">
+        {{> callin_resolution_buttons callin=this}}
+      </td>
     {{else}}
     <td class="text-warning">Log in to resolve answers in queue.</td>
     {{/if}}

--- a/callins.less
+++ b/callins.less
@@ -72,3 +72,11 @@ div.interaction {
   &::before { content: "(" }
   &::after { content: ")" }
 }
+input.input-compact {
+  font-size: 10.5px;
+  padding: 0px 6px;
+  width: 60px;
+}
+.bb-callin-allows-response {
+  white-space: nowrap;
+}

--- a/client/callins.coffee
+++ b/client/callins.coffee
@@ -84,28 +84,9 @@ Template.callin_row.helpers
       return true if wrong.answer is @answer
     return false
   callinTypeIs: (type) -> @callin_type is type
-  allowsResponse: -> @callin_type isnt callin_types.ANSWER
-  allowsIncorrect: -> @callin_type isnt callin_types.EXPECTED_CALLBACK
   nickEmail: -> nickEmail @
 
 Template.callin_row.events
-  "click .bb-callin-correct": (event, template) ->
-    response = template.find("input.response")?.value
-    if response? and response isnt ''
-      Meteor.call 'correctCallIn', @_id, response
-    else
-      Meteor.call 'correctCallIn', @_id
-
-  "click .bb-callin-incorrect": (event, template) ->
-    response = template.find("input.response")?.value
-    if response? and response isnt ''
-      Meteor.call 'incorrectCallIn', @_id, response
-    else
-      Meteor.call 'incorrectCallIn', @_id
-
-  "click .bb-callin-cancel": (event, template) ->
-    Meteor.call 'cancelCallIn', id: @_id
-
   "change .bb-submitted-to-hq": (event, template) ->
     checked = !!event.currentTarget.checked
     Meteor.call 'setField',
@@ -123,3 +104,27 @@ Template.callin_row.events
         submitted_to_hq: true
         submitted_by: Meteor.userId()
 
+Template.callin_resolution_buttons.helpers
+  allowsResponse: -> @callin.callin_type isnt callin_types.ANSWER
+  allowsIncorrect: -> @callin.callin_type isnt callin_types.EXPECTED_CALLBACK
+  accept_message: -> callin_types.accept_message @callin.callin_type
+  reject_message: -> callin_types.reject_message @callin.callin_type
+  cancel_message: -> callin_types.cancel_message @callin.callin_type
+
+Template.callin_resolution_buttons.events
+  "click .bb-callin-correct": (event, template) ->
+    response = template.find("input.response")?.value
+    if response? and response isnt ''
+      Meteor.call 'correctCallIn', @callin._id, response
+    else
+      Meteor.call 'correctCallIn', @callin._id
+
+  "click .bb-callin-incorrect": (event, template) ->
+    response = template.find("input.response")?.value
+    if response? and response isnt ''
+      Meteor.call 'incorrectCallIn', @callin._id, response
+    else
+      Meteor.call 'incorrectCallIn', @callin._id
+
+  "click .bb-callin-cancel": (event, template) ->
+    Meteor.call 'cancelCallIn', id: @callin._id

--- a/client/callins.coffee
+++ b/client/callins.coffee
@@ -17,7 +17,7 @@ Meteor.startup ->
     sub = Meteor.subscribe 'callins'
     return unless sub.ready() # reactive, will re-execute when ready
     initial = true
-    model.CallIns.find({}).observe
+    model.CallIns.find({status: 'pending'}).observe
       added: (doc) ->
         return if initial
         console.log 'ding dong'
@@ -36,7 +36,7 @@ Template.callins.onCreated ->
 
 Template.callins.helpers
   callins: ->
-    model.CallIns.find {},
+    model.CallIns.find {status: 'pending'},
       sort: [["created","asc"]]
       transform: (c) ->
         c.puzzle = if c.target then model.Puzzles.findOne(_id: c.target)

--- a/client/header.coffee
+++ b/client/header.coffee
@@ -117,10 +117,11 @@ Template.registerHelper 'pretty_ts', (args) ->
       if diff > 86400000
         return past_fmt.format d
       today_fmt.format d
-    when "duration", "brief_duration", "brief duration"
+    when "duration", "brief_duration", "brief duration", 'seconds_since'
       brief = (style isnt 'duration')
       duration = (Session.get('currentTime') or model.UTCNow()) - timestamp
       seconds = Math.floor(duration/1000)
+      return seconds if style is 'seconds_since'
       return "in the future" if seconds < -60
       return "just now" if seconds < 60
       [minutes, seconds] = [Math.floor(seconds/60), seconds % 60]

--- a/client/main.coffee
+++ b/client/main.coffee
@@ -2,6 +2,7 @@
 
 import { nickEmail } from './imports/nickEmail.coffee'
 import abbrev from '../lib/imports/abbrev.coffee'
+import { human_readable, abbrev as ctabbrev } from '../lib/imports/callin_types.coffee'
 import { mechanics } from '../lib/imports/mechanics.coffee'
 import { reactiveLocalStorage } from './imports/storage.coffee'
 import embeddable from './imports/embeddable.coffee'
@@ -20,11 +21,14 @@ chat = share.chat # import
 #   "quips"      -- view/edit phone-answering quips
 #   "facts"      -- server performance information
 Template.registerHelper "equal", (a, b) -> a is b
+Template.registerHelper "less", (a, b) -> a < b
 
 # session variables we want to make available from all templates
 do -> for v in ['currentPage']
   Template.registerHelper v, () -> Session.get(v)
 Template.registerHelper 'abbrev', abbrev
+Template.registerHelper 'callinType', human_readable
+Template.registerHelper 'callinTypeAbbrev', ctabbrev
 Template.registerHelper 'currentPageEquals', (arg) ->
   # register a more precise dependency on the value of currentPage
   Session.equals 'currentPage', arg

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -1,5 +1,6 @@
 'use strict'
 
+import { nickEmail } from './imports/nickEmail.coffee'
 import color from './imports/objectColor.coffee'
 import embeddable from './imports/embeddable.coffee'
 import * as callin_types from '/lib/imports/callin_types.coffee'
@@ -53,6 +54,7 @@ Template.puzzle_info.helpers
     ,
       sort: {created: 1}
   callin_status: -> callin_types.past_status_message @status, @callin_type
+  nickEmail: -> nickEmail @
 
   unsetcaredabout: ->
     return unless @puzzle

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -30,6 +30,12 @@ currentViewIs = (puzzle, view) ->
   return false if possible.includes Session.get 'view'
   return view is possible[0]
 
+Template.puzzle_info.onCreated ->
+  @autorun =>
+    id = Session.get 'id'
+    return unless id
+    @subscribe 'callins-by-puzzle', id
+
 Template.puzzle_info.helpers
   tag: (name) -> (model.getTag this, name) or ''
   getPuzzle: -> model.Puzzles.findOne this
@@ -39,6 +45,14 @@ Template.puzzle_info.helpers
       name: tag
       canon: model.canonical tag
     ) for tag in cared?.split(',') or []
+  callins: ->
+    return unless @puzzle?
+    model.CallIns.find
+      target_type: 'puzzles'
+      target: @puzzle._id
+    ,
+      sort: {created: 1}
+  callin_status: -> callin_types.past_status_message @status, @callin_type
 
   unsetcaredabout: ->
     return unless @puzzle

--- a/lib/imports/callin_types.coffee
+++ b/lib/imports/callin_types.coffee
@@ -5,3 +5,39 @@ export ANSWER = 'answer'
 export EXPECTED_CALLBACK = 'expected callback'
 export INTERACTION_REQUEST = 'interaction request'
 export MESSAGE_TO_HQ = 'message to hq'
+
+export human_readable = (type) ->
+  switch type
+    when ANSWER then 'Answer'
+    when EXPECTED_CALLBACK then 'Expected Callback'
+    when INTERACTION_REQUEST then 'Interaction Request'
+    when MESSAGE_TO_HQ then 'Message to HQ'
+    else "Unknown type #{type}"
+
+export abbrev = (type) ->
+  switch type
+    when ANSWER then 'A'
+    when EXPECTED_CALLBACK then 'EC'
+    when INTERACTION_REQUEST then 'IR'
+    when MESSAGE_TO_HQ then 'MHQ'
+    else '?'
+
+export accept_message = (type) ->
+  switch type
+    when ANSWER then 'Correct'
+    when EXPECTED_CALLBACK then 'Received'
+    else 'Accepted'
+
+export reject_message = (type) ->
+  switch type
+    when ANSWER then 'Incorrect'
+    else 'Rejected'
+
+export cancel_message = (type) -> "Cancel"
+
+export past_status_message = (status, type) ->
+  switch status
+    when 'cancelled' then "Cancelled"
+    when 'accepted' then accept_message type
+    when 'rejected' then reject_message type
+    when 'pending' then 'Pending'

--- a/lib/methods/addIncorrectAnswer.test.coffee
+++ b/lib/methods/addIncorrectAnswer.test.coffee
@@ -46,11 +46,13 @@ describe 'addIncorrectAnswer', ->
         tags: status: {name: 'Status', value: 'stuck', touched: 2, touched_by: 'torgen'}
         incorrectAnswers: [{answer: 'qux', who: 'torgen', timestamp: 2, backsolve: false, provided: false}]
       model.CallIns.insert
+        target_type: 'puzzles'
         target: id
         name: 'Foo'
         answer: 'flimflam'
         created: 4
         created_by: 'cjb'
+        status: 'pending'
         
     it 'fails without login', ->
       chai.assert.throws ->
@@ -92,5 +94,6 @@ describe 'addIncorrectAnswer', ->
         # oplog is lowercase
         chai.assert.include o[0].body, 'flimflam', 'message'
 
-      it 'deletes callin', ->
-        chai.assert.lengthOf model.CallIns.find().fetch(), 0
+      it 'updates callin', ->
+        chai.assert.include model.CallIns.findOne(),
+          status: 'rejected'

--- a/lib/methods/addIncorrectAnswer.test.coffee
+++ b/lib/methods/addIncorrectAnswer.test.coffee
@@ -44,7 +44,6 @@ describe 'addIncorrectAnswer', ->
         solved: null
         solved_by: null
         tags: status: {name: 'Status', value: 'stuck', touched: 2, touched_by: 'torgen'}
-        incorrectAnswers: [{answer: 'qux', who: 'torgen', timestamp: 2, backsolve: false, provided: false}]
       model.CallIns.insert
         target_type: 'puzzles'
         target: id
@@ -52,6 +51,7 @@ describe 'addIncorrectAnswer', ->
         answer: 'flimflam'
         created: 4
         created_by: 'cjb'
+        callin_type: 'answer'
         status: 'pending'
         
     it 'fails without login', ->
@@ -66,16 +66,6 @@ describe 'addIncorrectAnswer', ->
         callAs 'addIncorrectAnswer', 'cjb',
           target: id
           answer: 'flimflam'
-
-      it 'appends answer', ->
-        doc = model.Puzzles.findOne id
-        chai.assert.lengthOf doc.incorrectAnswers, 2
-        chai.assert.include doc.incorrectAnswers[1],
-          answer: 'flimflam'
-          who: 'cjb'
-          timestamp: 7
-          backsolve: false
-          provided: false
 
       it 'doesn\'t touch', ->
         doc = model.Puzzles.findOne id

--- a/lib/methods/cancelCallIn.test.coffee
+++ b/lib/methods/cancelCallIn.test.coffee
@@ -46,6 +46,7 @@ describe 'cancelCallIn', ->
       submitted_to_hq: true
       backsolve: false
       provided: false
+      status: 'pending'
       
   it 'fails without login', ->
     chai.assert.throws ->
@@ -56,8 +57,10 @@ describe 'cancelCallIn', ->
     beforeEach ->
       callAs 'cancelCallIn', 'cjb', id: callin
 
-    it 'deletes callin', ->
-      chai.assert.isUndefined model.CallIns.findOne()
+    it 'updates callin', ->
+      c = model.CallIns.findOne()
+      chai.assert.include c,
+        status: 'cancelled'
     
     it 'oplogs', ->
       chai.assert.lengthOf model.Messages.find({type: 'puzzles', id: puzzle}).fetch(), 1

--- a/lib/methods/correctCallIn.test.coffee
+++ b/lib/methods/correctCallIn.test.coffee
@@ -51,6 +51,7 @@ describe 'correctCallIn', ->
         submitted_to_hq: true
         backsolve: false
         provided: false
+        status: 'pending'
     
     it 'fails without login', ->
       chai.assert.throws ->
@@ -80,8 +81,10 @@ describe 'correctCallIn', ->
             touched: 7
             touched_by: 'cjb'
       
-      it 'removes callin', ->
-        chai.assert.isUndefined model.CallIns.findOne callin
+      it 'updates callin', ->
+        c = model.CallIns.findOne callin
+        chai.assert.include c,
+          status: 'accepted'
 
       it 'oplogs', ->
         o = model.Messages.find(room_name: 'oplog/0', dawn_of_time: $ne: true).fetch()
@@ -161,6 +164,7 @@ describe 'correctCallIn', ->
         submitted_to_hq: true
         backsolve: false
         provided: false
+        status: 'pending'
     
     it 'fails without login', ->
       chai.assert.throws ->
@@ -182,8 +186,10 @@ describe 'correctCallIn', ->
             confirmed_by: null
             tags: {}
         
-        it 'removes callin', ->
-          chai.assert.isUndefined model.CallIns.findOne callin
+        it 'updates callin', ->
+          c = model.CallIns.findOne callin
+          chai.assert.include c,
+            status: 'accepted'
 
         it 'does not oplog', ->
           o = model.Messages.find(room_name: 'oplog/0', dawn_of_time: $ne: true).fetch()
@@ -222,8 +228,11 @@ describe 'correctCallIn', ->
           confirmed_by: null
           tags: {}
       
-      it 'removes callin', ->
-        chai.assert.isUndefined model.CallIns.findOne callin
+      it 'updates callin', ->
+        c = model.CallIns.findOne callin
+        chai.assert.include c,
+          status: 'accepted'
+          response: 'Make us some supersaturated Kool-Aid'
 
       it 'does not oplog', ->
         o = model.Messages.find(room_name: 'oplog/0', dawn_of_time: $ne: true).fetch()
@@ -316,8 +325,10 @@ describe 'correctCallIn', ->
             confirmed_by: null
             tags: {}
         
-        it 'removes callin', ->
-          chai.assert.isUndefined model.CallIns.findOne callin
+        it 'updates callin', ->
+          c = model.CallIns.findOne callin
+          chai.assert.include c,
+            status: 'accepted'
 
         it 'does not oplog', ->
           o = model.Messages.find(room_name: 'oplog/0', dawn_of_time: $ne: true).fetch()
@@ -356,8 +367,11 @@ describe 'correctCallIn', ->
           confirmed_by: null
           tags: {}
       
-      it 'removes callin', ->
-        chai.assert.isUndefined model.CallIns.findOne callin
+      it 'updates callin', ->
+        c = model.CallIns.findOne callin
+        chai.assert.include c,
+          status: 'accepted'
+          response: 'Make us some supersaturated Kool-Aid'
 
       it 'does not oplog', ->
         o = model.Messages.find(room_name: 'oplog/0', dawn_of_time: $ne: true).fetch()
@@ -450,8 +464,10 @@ describe 'correctCallIn', ->
             confirmed_by: null
             tags: {}
         
-        it 'removes callin', ->
-          chai.assert.isUndefined model.CallIns.findOne callin
+        it 'updates callin', ->
+          c = model.CallIns.findOne callin
+          chai.assert.include c,
+            status: 'accepted'
 
         it 'does not oplog', ->
           o = model.Messages.find(room_name: 'oplog/0', dawn_of_time: $ne: true).fetch()
@@ -491,8 +507,11 @@ describe 'correctCallIn', ->
           confirmed_by: null
           tags: {}
       
-      it 'removes callin', ->
-        chai.assert.isUndefined model.CallIns.findOne callin
+      it 'updates callin', ->
+        c = model.CallIns.findOne callin
+        chai.assert.include c,
+          status: 'accepted'
+          response: 'Make us some supersaturated Kool-Aid'
 
       it 'does not oplog', ->
         o = model.Messages.find(room_name: 'oplog/0', dawn_of_time: $ne: true).fetch()

--- a/lib/methods/incorrectCallIn.test.coffee
+++ b/lib/methods/incorrectCallIn.test.coffee
@@ -51,6 +51,7 @@ describe 'incorrectCallIn', ->
         submitted_to_hq: true
         backsolve: false
         provided: false
+        status: 'pending'
 
     it 'fails without login', ->
       chai.assert.throws ->
@@ -61,8 +62,10 @@ describe 'incorrectCallIn', ->
       beforeEach ->
         callAs 'incorrectCallIn', 'cjb', callin
 
-      it 'deletes callin', ->
-        chai.assert.isUndefined model.CallIns.findOne()
+      it 'updates callin', ->
+        c = model.CallIns.findOne callin
+        chai.assert.include c,
+          status: 'rejected'
 
       it 'addsIncorrectAnswer', ->
         chai.assert.deepInclude model.Puzzles.findOne(puzzle),
@@ -101,6 +104,7 @@ describe 'incorrectCallIn', ->
         submitted_to_hq: true
         backsolve: false
         provided: false
+        status: 'pending'
 
     describe 'without response', ->
 
@@ -113,8 +117,10 @@ describe 'incorrectCallIn', ->
         beforeEach ->
           callAs 'incorrectCallIn', 'cjb', callin
 
-        it 'deletes callin', ->
-          chai.assert.isUndefined model.CallIns.findOne()
+        it 'updates callin', ->
+          c = model.CallIns.findOne callin
+          chai.assert.include c,
+            status: 'rejected'
 
         it 'does not add incorrectAnswer', ->
           chai.assert.isUndefined model.Puzzles.findOne(puzzle).incorrectAnswers
@@ -153,8 +159,11 @@ describe 'incorrectCallIn', ->
         beforeEach ->
           callAs 'incorrectCallIn', 'cjb', callin, 'sediment'
 
-        it 'deletes callin', ->
-          chai.assert.isUndefined model.CallIns.findOne()
+        it 'updates callin', ->
+          c = model.CallIns.findOne callin
+          chai.assert.include c,
+            status: 'rejected'
+            response: 'sediment'
 
         it 'does not add incorrectAnswer', ->
           chai.assert.isUndefined model.Puzzles.findOne(puzzle).incorrectAnswers
@@ -208,6 +217,7 @@ describe 'incorrectCallIn', ->
         submitted_to_hq: true
         backsolve: false
         provided: false
+        status: 'pending'
 
     describe 'without response', ->
 
@@ -220,8 +230,10 @@ describe 'incorrectCallIn', ->
         beforeEach ->
           callAs 'incorrectCallIn', 'cjb', callin
 
-        it 'deletes callin', ->
-          chai.assert.isUndefined model.CallIns.findOne()
+        it 'updates callin', ->
+          c = model.CallIns.findOne callin
+          chai.assert.include c,
+            status: 'rejected'
 
         it 'does not add incorrectAnswer', ->
           chai.assert.isUndefined model.Puzzles.findOne(puzzle).incorrectAnswers
@@ -260,8 +272,11 @@ describe 'incorrectCallIn', ->
         beforeEach ->
           callAs 'incorrectCallIn', 'cjb', callin, 'sediment'
 
-        it 'deletes callin', ->
-          chai.assert.isUndefined model.CallIns.findOne()
+        it 'updates callin', ->
+          c = model.CallIns.findOne callin
+          chai.assert.include c,
+            status: 'rejected'
+            response: 'sediment'
 
         it 'does not add incorrectAnswer', ->
           chai.assert.isUndefined model.Puzzles.findOne(puzzle).incorrectAnswers
@@ -315,6 +330,7 @@ describe 'incorrectCallIn', ->
         submitted_to_hq: true
         backsolve: false
         provided: false
+        status: 'pending'
 
     describe 'without response', ->
 

--- a/lib/methods/incorrectCallIn.test.coffee
+++ b/lib/methods/incorrectCallIn.test.coffee
@@ -67,10 +67,6 @@ describe 'incorrectCallIn', ->
         chai.assert.include c,
           status: 'rejected'
 
-      it 'addsIncorrectAnswer', ->
-        chai.assert.deepInclude model.Puzzles.findOne(puzzle),
-          incorrectAnswers: [{answer: 'precipitate', who: 'cjb', timestamp: 7, backsolve: false, provided: false}]
-
       it 'oplogs', ->
         chai.assert.lengthOf model.Messages.find({type: 'puzzles', id: puzzle, stream: 'callins'}).fetch(), 1
 

--- a/lib/methods/newCallIn.test.coffee
+++ b/lib/methods/newCallIn.test.coffee
@@ -99,6 +99,7 @@ describe 'newCallIn', ->
             submitted_to_hq: false
             backsolve: false
             provided: false
+            status: 'pending'
 
         it 'oplogs', ->
           o = model.Messages.find(room_name: 'oplog/0', dawn_of_time: $ne: true).fetch()
@@ -142,6 +143,7 @@ describe 'newCallIn', ->
           submitted_to_hq: false
           backsolve: true
           provided: false
+          status: 'pending'
       
       it 'sets provided', ->
         callAs 'newCallIn', 'torgen',
@@ -156,6 +158,7 @@ describe 'newCallIn', ->
           submitted_to_hq: false
           backsolve: false
           provided: true
+          status: 'pending'
 
     it 'notifies meta chat for puzzle', ->
       meta = model.Puzzles.insert
@@ -299,6 +302,7 @@ describe 'newCallIn', ->
             callin_type: 'interaction request'
             who: 'torgen'
             submitted_to_hq: false
+            status: 'pending'
 
         it 'oplogs', ->
           o = model.Messages.find(room_name: 'oplog/0', dawn_of_time: $ne: true).fetch()
@@ -427,6 +431,7 @@ describe 'newCallIn', ->
             callin_type: 'message to hq'
             who: 'torgen'
             submitted_to_hq: false
+            status: 'pending'
 
         it 'oplogs', ->
           o = model.Messages.find(room_name: 'oplog/0', dawn_of_time: $ne: true).fetch()
@@ -555,6 +560,7 @@ describe 'newCallIn', ->
             callin_type: 'expected callback'
             who: 'torgen'
             submitted_to_hq: false
+            status: 'pending'
 
         it 'oplogs', ->
           o = model.Messages.find(room_name: 'oplog/0', dawn_of_time: $ne: true).fetch()

--- a/lib/methods/setAnswer.test.coffee
+++ b/lib/methods/setAnswer.test.coffee
@@ -220,6 +220,7 @@ describe 'setAnswer', ->
         confirmed_by: null
         tags: {}
       cid1 = model.CallIns.insert
+        target_type: 'puzzles'
         target: id
         name: 'Foo'
         answer: 'bar'
@@ -229,7 +230,9 @@ describe 'setAnswer', ->
         submitted_to_hq: true
         backsolve: false
         provided: false
+        status: 'pending'
       cid2 = model.CallIns.insert
+        target_type: 'puzzles'
         target: id
         name: 'Foo'
         answer: 'qux'
@@ -239,18 +242,22 @@ describe 'setAnswer', ->
         submitted_to_hq: false
         backsolve: false
         provided: false
+        status: 'pending'
       callAs 'setAnswer', 'cjb',
         target: id
         answer: 'bar'
         
-    it 'deletes callins', ->
-      chai.assert.lengthOf model.CallIns.find().fetch(), 0
+    it 'updates callins', ->
+      chai.assert.include model.CallIns.findOne(cid1),
+        status: 'accepted'
+      chai.assert.include model.CallIns.findOne(cid2),
+        status: 'cancelled'
 
     it 'doesn\'t oplog for callins', ->
       chai.assert.lengthOf model.Messages.find({room_name: 'oplog/0', type: 'callins'}).fetch(), 0
 
     it 'oplogs for puzzle', ->
-      chai.assert.lengthOf model.Messages.find({room_name: 'oplog/0', type: 'puzzles', id: id}).fetch(), 2
+      chai.assert.lengthOf model.Messages.find({room_name: 'oplog/0', type: 'puzzles', id: id}).fetch(), 1
 
     it 'sets solved_by correctly', ->
       chai.assert.deepInclude model.Puzzles.findOne(id),

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -126,10 +126,13 @@ if Meteor.isServer
 #   submitted_by: canon of Nick
 #   backsolve: true/false
 #   provided: true/false
+#   status: one of 'pending', 'accepted', 'rejected', or 'cancelled'.
+#   response: (optional) response from HQ to this callin
 CallIns = BBCollection.callins = new Mongo.Collection "callins"
 if Meteor.isServer
-  CallIns._ensureIndex {created: 1}, {}
-  CallIns._ensureIndex {target: 1, answer: 1}, {unique:true, dropDups:true}
+  CallIns._ensureIndex {status: 1, created: 1}
+  CallIns._ensureIndex {status: 1, target_type: 1, target: 1, callin_type: 1, answer: 1}, {unique:true, dropDups:true, partialFilterExpression: {status: 'pending'}}
+  CallIns._ensureIndex {target_type: 1, target: 1, created: 1}
 
 # Quips are:
 #   _id: mongodb id
@@ -679,6 +682,7 @@ doc_id_to_link = (id) ->
         submitted_to_hq: false
         backsolve: !!args.backsolve
         provided: !!args.provided
+        status: 'pending'
       , {suppressLog:true}
       msg = action: true
       # send to the general chat
@@ -760,7 +764,9 @@ doc_id_to_link = (id) ->
           body: "reports that #{provided}#{backsolve}#{callin.answer.toUpperCase()} is CORRECT!"
       else
         check response, Match.Optional String
+        updateBody = status: 'accepted'
         extra = if response?
+          updateBody.response = response
           " with response \"#{response}\""
         else
           ''
@@ -773,9 +779,8 @@ doc_id_to_link = (id) ->
 
         Object.assign msg,
           body: "reports that the #{type_text} \"#{callin.answer}\" was #{verb}#{extra}!"
-        Meteor.call 'cancelCallIn',
-          id: id
-          suppressLog: true
+        CallIns.update _id: id,
+          $set: updateBody
 
       # one message to the puzzle chat
       Meteor.call 'newMessage', msg
@@ -816,7 +821,9 @@ doc_id_to_link = (id) ->
         throw new Meteor.Error(400, 'expected callback can\'t be incorrect')
       else
         check response, Match.Optional String
+        updateBody = status: 'rejected'
         extra = if response?
+          updateBody.response = response
           " with response \"#{response}\""
         else
           ''
@@ -826,9 +833,8 @@ doc_id_to_link = (id) ->
 
         Object.assign msg,
           body: "sadly relays that the #{type_text} \"#{callin.answer}\" was REJECTED#{extra}."
-        Meteor.call 'cancelCallIn',
-          id: id
-          suppressLog: true
+        CallIns.update _id: id,
+          $set: updateBody
 
       # one message to the puzzle chat
       Meteor.call 'newMessage', msg
@@ -853,10 +859,8 @@ doc_id_to_link = (id) ->
       unless args.suppressLog
         oplog "Canceled call-in of #{callin.answer} for", 'puzzles', \
             callin.target, @userId
-      deleteObject "callins",
-        id: args.id
-        who: @userId
-      , {suppressLog:true}
+      CallIns.update _id: args.id,
+        $set: status: 'cancelled'
 
     locateNick: (args) ->
       check @userId, NonEmptyString
@@ -1236,10 +1240,12 @@ doc_id_to_link = (id) ->
       return false if updated is 0
       oplog "Found an answer (#{args.answer.toUpperCase()}) to", 'puzzles', id, @userId, 'answers'
       # cancel any entries on the call-in queue for this puzzle
-      for c in CallIns.find(target: id).fetch()
-        Meteor.call 'cancelCallIn',
-          id: c._id
-          suppressLog: (c.answer is args.answer)
+      CallIns.update {target_type: 'puzzles', target: id, status: 'pending', callin_type: 'answer', answer: args.answer},
+        $set: status: 'accepted'
+      CallIns.update {target_type: 'puzzles', target: id, status: 'pending'},
+        $set: status: 'cancelled'
+      ,
+        multi: true
       return true
 
     addIncorrectAnswer: (args) ->
@@ -1265,10 +1271,9 @@ doc_id_to_link = (id) ->
       oplog "reports incorrect answer #{args.answer} for", 'puzzles', id, @userId, \
           'callins'
       # cancel any matching entries on the call-in queue for this puzzle
-      for c in CallIns.find(target: id, answer: args.answer).fetch()
-        Meteor.call 'cancelCallIn',
-          id: c._id
-          suppressLog: true
+      # The 'pending' status means this should be unique if present.
+      CallIns.update {target_type: 'puzzles', target: id, status: 'pending', answer: args.answer},
+        $set: status: 'rejected'
       return true
 
     deleteAnswer: (args) ->

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -859,7 +859,7 @@ doc_id_to_link = (id) ->
       unless args.suppressLog
         oplog "Canceled call-in of #{callin.answer} for", 'puzzles', \
             callin.target, @userId
-      CallIns.update _id: args.id,
+      CallIns.update _id: args.id, status: 'pending',
         $set: status: 'cancelled'
 
     locateNick: (args) ->
@@ -1260,13 +1260,6 @@ doc_id_to_link = (id) ->
 
       target = Puzzles.findOne(id)
       throw new Meteor.Error(400, "bad target") unless target
-      Puzzles.update id, $push:
-        incorrectAnswers:
-          answer: args.answer
-          timestamp: UTCNow()
-          who: @userId
-          backsolve: !!args.backsolve
-          provided: !!args.provided
 
       oplog "reports incorrect answer #{args.answer} for", 'puzzles', id, @userId, \
           'callins'

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -1240,7 +1240,7 @@ doc_id_to_link = (id) ->
       return false if updated is 0
       oplog "Found an answer (#{args.answer.toUpperCase()}) to", 'puzzles', id, @userId, 'answers'
       # cancel any entries on the call-in queue for this puzzle
-      CallIns.update {target_type: 'puzzles', target: id, status: 'pending', callin_type: 'answer', answer: args.answer},
+      CallIns.update {target_type: 'puzzles', target: id, status: 'pending', callin_type: callin_types.ANSWER, answer: args.answer},
         $set: status: 'accepted'
       CallIns.update {target_type: 'puzzles', target: id, status: 'pending'},
         $set: status: 'cancelled'
@@ -1265,7 +1265,7 @@ doc_id_to_link = (id) ->
           'callins'
       # cancel any matching entries on the call-in queue for this puzzle
       # The 'pending' status means this should be unique if present.
-      CallIns.update {target_type: 'puzzles', target: id, status: 'pending', answer: args.answer},
+      CallIns.update {target_type: 'puzzles', callin_type: callin_types.ANSWER, target: id, status: 'pending', answer: args.answer},
         $set: status: 'rejected'
       return true
 

--- a/puzzle.html
+++ b/puzzle.html
@@ -58,6 +58,12 @@
           <td class="form-inline">
             {{#if equal status "pending"}}
               {{>callin_resolution_buttons callin=this compact=true}}
+              {{#with submitted_by}}
+                <span title="Submitted by {{nickOrName this}}">
+                  <i class="fas fa-phone"></i>
+                  {{gravatar id=nickEmail image="wavatar" size=20}}
+                </span>
+              {{/with}}
             {{else}}
               <span class="btn disabled active btn-mini btn-{{#if equal status "accepted"}}success
                                         {{else if equal status "rejected"}}danger

--- a/puzzle.html
+++ b/puzzle.html
@@ -11,10 +11,6 @@
     <tr><td class="rightanswer">Answer:</td><td class="answer">{{tag "answer"}}</td></tr>
     <tr><td class="backsolve">{{#if tag "backsolved"}}(backsolved){{/if}}</td><td class="timestamp">{{pretty_ts solved}}</td></tr>
   {{/if}}
-  {{#each incorrectAnswers}}
-    <tr><td class="wronganswer">IncorrectAnswer:</td><td class="answer">{{answer}}</td></tr>
-    <tr><td class="backsolve">{{#if backsolve}}(backsolved){{/if}}</td><td class="timestamp">{{pretty_ts timestamp}}</td></tr>
-  {{/each}}
   <tr><td>Mechanics:</td><td>{{> puzzle_mechanics}}</td></tr>
 {{/with}}
 {{#each cares in unsetcaredabout}}
@@ -36,6 +32,46 @@
 {{/with}}
 </tbody></table>
 {{> starred_messages canModify=mynick}}
+{{#let cs=callins}}
+  {{#if cs.count}}
+    <h3>Callin History</h3>
+    <table class="bb-callin-history table table-bordered table-condensed">
+      <thead>
+        <tr>
+          <th colspan="2">Callin</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+      {{#each cs}}
+        <tr>
+          <td class="answer">{{answer}}</td>
+          <td class="bb-callin-metadata">
+            <span class="label label-info" title="{{callinType callin_type}}">{{callinTypeAbbrev callin_type}}</span>
+            {{#let since=(pretty_ts timestamp=created style="seconds_since")}}
+              <i class="fas fa-{{#if less since 1200}}hourglass-start
+                                {{else if less since 2400}}hourglass-half
+                                {{else if less since 3600}}hourglass-end
+                                {{else if less since 86400}}clock
+                                {{else}}calendar{{/if}}" title="Created at {{pretty_ts timestamp=created}}"></i>
+            {{/let}}</td>
+          <td class="form-inline">
+            {{#if equal status "pending"}}
+              {{>callin_resolution_buttons callin=this compact=true}}
+            {{else}}
+              <span class="btn disabled active btn-mini btn-{{#if equal status "accepted"}}success
+                                        {{else if equal status "rejected"}}danger
+                                        {{else if equal status "cancelled"}}warning
+                                        {{/if}}">{{callin_status}}</span>
+              {{#with response}}<i class="fas fa-arrow-right"></i>&ldquo;{{this}}&rdquo;{{/with}}
+            {{/if}}
+          </td>
+        </tr>
+      {{/each}}
+      </tbody>
+    </table>
+  {{/if}}
+{{/let}}
 {{#if puzzle.puzzles}}{{#let cares=caresabout}}
 <table class="bb-round-answers table table-bordered table-condensed"><tbody>
   <tr><th>Puzzle in round</th><th>Answer</th>{{#each cares}}<th>{{name}}</th>{{/each}}</tr>

--- a/server/batch.coffee
+++ b/server/batch.coffee
@@ -11,6 +11,16 @@ model = share.model
 # Was in lib/model.coffee, but that meant it was loaded on the client even
 # though it could never run there.
 
+model.CallIns.update
+  status: null
+,
+  $set: status: 'pending'
+,
+  multi: true
+try
+  Promise.await model.CallIns.rawCollection().dropIndex('target_1_answer_1')
+# No problem if it doesn't exist.
+
 # helper function: like _.throttle, but always ensures `wait` of idle time
 # between invocations.  This ensures that we stay chill even if a single
 # execution of the function starts to exceed `wait`.

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -126,6 +126,7 @@ Meteor.publish 'last-answered-puzzle', loginRequired ->
 # limit site traffic by only pushing out changes relevant to a certain
 # round or puzzle
 Meteor.publish 'puzzle-by-id', loginRequired (id) -> @puzzleQuery _id: id
+Meteor.publish 'callins-by-puzzle', loginRequired (id) -> model.CallIns.find {target_type: 'puzzles', target: id}
 Meteor.publish 'metas-for-puzzle', loginRequired (id) -> @puzzleQuery puzzles: id
 Meteor.publish 'round-by-id', loginRequired (id) -> model.Rounds.find _id: id
 Meteor.publish 'round-for-puzzle', loginRequired (id) -> model.Rounds.find puzzles: id

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -165,7 +165,7 @@ Meteor.publish 'starred-messages', loginRequired (room_name) ->
     sort: [["timestamp", "asc"]]
 
 Meteor.publish 'callins', loginRequired ->
-  model.CallIns.find {},
+  model.CallIns.find {status: 'pending'},
     sort: [["created","asc"]]
 
 Meteor.publish 'quips', loginRequired ->


### PR DESCRIPTION
Adds a status field to callins which starts at "pending" and updates to "accepted", "rejected", or "cancelled" depending on resolution. The callins table only shows the pending callins.
Adds a table to the puzzle info page showing all callins for that puzzle including resolution, and for pending callins, buttons to resolve the callin immediately. 
Fixes #147. Fixes #149.