### PR TITLE
Increase parallelism in drive client

### DIFF
--- a/server/imports/drive.test.coffee
+++ b/server/imports/drive.test.coffee
@@ -134,22 +134,6 @@ describe 'drive', ->
         ]
         drive = new Drive api
 
-      it 'retries on throttle', ->
-        children.expects('list').withArgs sinon.match
-          folderId: 'hunt'
-          q: 'title=\'New Puzzle\''
-          maxResults: 1
-        .exactly(8).callsFake ->
-            process.nextTick -> clock.next()
-            Promise.reject
-              code: 403
-              errors: [
-                domain: 'usageLimits'
-                reason: 'userRateLimitExceeded'
-              ]
-        chai.assert.throws ->
-          drive.createPuzzle 'New Puzzle'
-
       describe 'createPuzzle', ->
         it 'creates', ->
           children.expects('list').withArgs sinon.match


### PR DESCRIPTION
When creating a new puzzle, create the spreadsheet and doc in parallel. Also, start creating the spreadsheet and doc while waiting to set the permissions on the folder.
When setting permissions on an object, set them all in parallel.
When renaming a puzzle, rename the folder, the spreadsheet, and the doc in parallel.
When deleting a directory, delete the contents in parallel.
Also removes apiThrottle, since the modern Google APIs client does this for us.

Did a quick speed test. On 3 puzzle creations in serial, the times were 7775.491ms, 11629.559ms, and 6735.919ms. On 3 creations in parallel, they were 5647.905ms, 4974.740ms, and 3702.866ms. 

Fixes #167 
