### PR TITLE
Allow changing type of pending callins

### DIFF
--- a/blackboard.less
+++ b/blackboard.less
@@ -141,7 +141,7 @@ body.has-emojis {
       background: white;
       .bb-status-stuck { background: #FF0; }
     }
-    .bb-mechanics-dropdown .btn {
+    .bb-mechanics-dropdown .btn, .bb-callin-type-dropdown {
       font-size: 10.5px;
       padding: 0 6px;
     }

--- a/callins.html
+++ b/callins.html
@@ -52,12 +52,10 @@
     {{/if}}{{#if solved}}<div class="dupe">Already Solved</div>{{/if}}</td>
     <td><div id="answer-{{_id}}" class="answer">{{answer}}</div>{{#if backsolve}}(backsolve){{/if}}{{#if provided}}(provided){{/if}}
       {{#if alreadyTried}}<div class="dupe">Already Tried</div>{{/if}}
-      {{#unless callinTypeIs "answer"}}
-        <div class="interaction">{{callinType callin_type}}</div>
-      {{/unless}}
+      {{>callin_type_dropdown}}
       {{#unless callinTypeIs "expected callback"}}
         {{#if hunt_link}}
-          <a href="{{hunt_link}}" target="_blank" class="copy-and-go btn btn-info btn-mini" data-clipboard-target="#answer-{{_id}}" title="copy, mark submitted, and go">
+          <a href="{{hunt_link}}" target="_blank" class="copy-and-go btn btn-primary btn-mini" data-clipboard-target="#answer-{{_id}}" title="copy, mark submitted, and go">
             <i class="fas fa-clipboard"></i><i class="fas fa-check"></i><i class="fas fa-share"></i>
           </a> 
         {{/if}}
@@ -78,6 +76,22 @@
     <td class="text-warning">Log in to resolve answers in queue.</td>
     {{/if}}
   </tr>
+</template>
+
+<template name="callin_type_dropdown">
+  <div class="btn-group">
+    <button class="btn btn-info dropdown-toggle bb-callin-type-dropdown {{#unless equal status "pending"}}disabled{{/unless}}" data-toggle="{{#if equal status "pending"}}dropdown{{/if}}" title="{{callinType callin_type}}">
+      {{callinTypeAbbrev callin_type}}
+      {{#if equal status "pending"}}<span class="caret"></span>{{/if}}
+    </button>
+    <ul class="dropdown-menu text-left">
+    {{#each ct in callinTypes}}
+      <li title="{{tooltip ct}}"><a data-callin-type="{{ct}}" href="#">
+        {{typeName ct}}
+      </a></li>
+    {{/each}}
+    </ul>
+  </div>
 </template>
 
 <template name="callin_resolution_buttons">

--- a/client/callins.coffee
+++ b/client/callins.coffee
@@ -108,6 +108,15 @@ Template.callin_row.events
         submitted_to_hq: true
         submitted_by: Meteor.userId()
 
+Template.callin_type_dropdown.events
+  'click a[data-callin-type]': (event, template) ->
+    Meteor.call 'setField',
+      type: 'callins'
+      object: @_id
+      fields:
+        callin_type: event.currentTarget.dataset.callinType
+
+
 Template.callin_resolution_buttons.helpers
   allowsResponse: -> @callin.callin_type isnt callin_types.ANSWER
   allowsIncorrect: -> @callin.callin_type isnt callin_types.EXPECTED_CALLBACK

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -168,26 +168,31 @@ Template.puzzle_callin_modal.onCreated ->
 Template.puzzle_callin_modal.onRendered ->
   @$("input[name='callin_type'][value='#{@type.get()}']").prop('checked', true)
 
+callinTypesHelpers = (template) ->
+  template.helpers
+    typeName: (type) -> switch (type ? Template.instance().type.get())
+      when callin_types.ANSWER then 'Answer'
+      when callin_types.INTERACTION_REQUEST then 'Interaction Request'
+      when callin_types.MESSAGE_TO_HQ then 'Message to HQ'
+      when callin_types.EXPECTED_CALLBACK then 'Expected Callback'
+      else ''
+    tooltip: (type) -> switch type
+      when callin_types.ANSWER then 'The solution to the puzzle. Fingers crossed!'
+      when callin_types.INTERACTION_REQUEST then 'An intermediate string that may trigger a skit, physical puzzle, or creative challenge.'
+      when callin_types.MESSAGE_TO_HQ then 'Any other reason for contacting HQ, including spending clue currency and reporting an error.'
+      when callin_types.EXPECTED_CALLBACK then 'We will be contacted by HQ. No immediate action is required of the oncall.'
+      else ''
+    callinTypes: -> [
+      callin_types.ANSWER,
+      callin_types.INTERACTION_REQUEST,
+      callin_types.MESSAGE_TO_HQ,
+      callin_types.EXPECTED_CALLBACK]
+
+callinTypesHelpers(Template.puzzle_callin_modal)
 Template.puzzle_callin_modal.helpers
   type: -> Template.instance().type.get()
   typeIs: (type) -> Template.instance().type.get() is type
-  typeName: (type) -> switch (type ? Template.instance().type.get())
-    when callin_types.ANSWER then 'Answer'
-    when callin_types.INTERACTION_REQUEST then 'Interaction Request'
-    when callin_types.MESSAGE_TO_HQ then 'Message to HQ'
-    when callin_types.EXPECTED_CALLBACK then 'Expected Callback'
-    else ''
-  tooltip: (type) -> switch type
-    when callin_types.ANSWER then 'The solution to the puzzle. Fingers crossed!'
-    when callin_types.INTERACTION_REQUEST then 'An intermediate string that may trigger a skit, physical puzzle, or creative challenge.'
-    when callin_types.MESSAGE_TO_HQ then 'Any other reason for contacting HQ, including spending clue currency and reporting an error.'
-    when callin_types.EXPECTED_CALLBACK then 'We will be contacted by HQ. No immediate action is required of the oncall.'
-    else ''
-  callinTypes: -> [
-    callin_types.ANSWER,
-    callin_types.INTERACTION_REQUEST,
-    callin_types.MESSAGE_TO_HQ,
-    callin_types.EXPECTED_CALLBACK]
+callinTypesHelpers(Template.callin_type_dropdown)
 
 Template.puzzle_callin_modal.events
   'change input[name="callin_type"]': (event, template) ->

--- a/puzzle.html
+++ b/puzzle.html
@@ -47,7 +47,7 @@
         <tr>
           <td class="answer">{{answer}}</td>
           <td class="bb-callin-metadata">
-            <span class="label label-info" title="{{callinType callin_type}}">{{callinTypeAbbrev callin_type}}</span>
+            {{> callin_type_dropdown}}
             {{#let since=(pretty_ts timestamp=created style="seconds_since")}}
               <i class="fas fa-{{#if less since 1200}}hourglass-start
                                 {{else if less since 2400}}hourglass-half


### PR DESCRIPTION
Both the callin page and the callin history table in the puzzle info have a dropdown for the callin type where a new type can be selected.
Fixes #161