### PR TITLE
Allow hiding old presence messages

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -160,9 +160,11 @@
     {{#each messages}}{{scrollHack}}
       {{#if message.dawn_of_time}}<!-- Channel creation -->
       {{else if message.presence}}
-        <div class="bb-message-presence {{message.presence}}" title="{{pretty_ts message.timestamp}}: {{cleanup message.body}}" data-read="{{#unless read}}un{{/unless}}read">
-          {{gravatar id=email image="wavatar" size=14 }}{{message.nick}}
-        </div>
+        {{#unless presence_too_old}}
+          <div class="bb-message-presence {{message.presence}}" title="{{pretty_ts message.timestamp}}: {{cleanup message.body}}" data-read="{{#unless read}}un{{/unless}}read">
+            {{gravatar id=email image="wavatar" size=14 }}{{message.nick}}
+          </div>
+        {{/unless}}
       {{else if message.system}}
         <div class="bb-message-system" data-read="{{#unless read}}un{{/unless}}read">
           <div class="pull-right timestamp">{{pretty_ts message.timestamp}}</div>

--- a/client/chat.coffee
+++ b/client/chat.coffee
@@ -198,6 +198,15 @@ Template.messages.helpers
             not m.useless_cmd) or \
         doesMentionNick(m) or \
         ('true' isnt reactiveLocalStorage.getItem 'nobot')
+  presence_too_old: ->
+    return false unless reactiveLocalStorage.getItem('hideOldPresence') is 'true'
+    # If a message is too old, it will always be too old unless the option changes,
+    # so don't re-evaluate the calculation every minute.
+    result = Tracker.nonreactive =>
+      @message.timestamp < Session.get('currentTime') - 3600
+    if !result
+      Session.get 'currentTime'
+    return result
   messages: ->
     room_name = Session.get 'room_name'
     # I will go out on a limb and say we need this because transform uses

--- a/client/options_dropdown.coffee
+++ b/client/options_dropdown.coffee
@@ -20,6 +20,7 @@ Template.registerHelper 'hideSolvedMeta', -> 'true' is reactiveLocalStorage.getI
 Template.registerHelper 'hideStatus', -> 'true' is reactiveLocalStorage.getItem 'hideStatus'
 Template.registerHelper 'stuckToTop', -> 'true' is reactiveLocalStorage.getItem 'stuckToTop'
 Template.registerHelper 'noBot', -> 'true' is reactiveLocalStorage.getItem 'nobot'
+Template.registerHelper 'hideOldPresence', -> 'true' is reactiveLocalStorage.getItem 'hideOldPresence'
 
 Template.options_dropdown.events
   'click .bb-display-settings li a': (event, template) ->
@@ -39,3 +40,5 @@ Template.options_dropdown.events
     reactiveLocalStorage.setItem 'stuckToTop', event.target.checked
   'change .bb-bot-mute input': (event, template) ->
     reactiveLocalStorage.setItem 'nobot', event.target.checked
+  'change .bb-hide-old-presence input': (event, template) ->
+    reactiveLocalStorage.setItem 'hideOldPresence', event.target.checked

--- a/options_dropdown.html
+++ b/options_dropdown.html
@@ -50,6 +50,12 @@
           Mute Bot Tomfoolery
         </label>
       </a></li>
+      <li><a name="bb-hide-old-presence">
+        <label class="checkbox bb-hide-old-presence" title="Hide join/part messages more than an hour old">
+          <input type="checkbox" name="bb-hide-old-presence" checked="{{hideOldPresence}}">
+          Hide Old Presence
+        </label>
+      </a></li>
     </ul>
   </div>
 </template>


### PR DESCRIPTION
Add options checkbox that hides all joins and parts older than 1h. Doesn't change subscriptions, so they are still sent to the client.
Fixes #169 