### PR TITLE
Store static jitsi room in a global dynamic setting

### DIFF
--- a/client/000startup/settings.coffee
+++ b/client/000startup/settings.coffee
@@ -25,12 +25,7 @@ settings.CHAT_LIMIT_INCREMENT = server.chatLimitIncrement ? 100
 
 # Used to generate video chat links
 # No default; if unset, don't generate links.
-settings.JITSI_SERVER = server.jitsi?.server
-
-# Puzzle rooms use meteor IDs, so they're not guessable. Static rooms like
-# general and callins don't, so they would be guessable; use this shared
-# secret so they aren't.
-settings.JITSI_STATIC_ROOM = server.jitsi?.staticRoom
+settings.JITSI_SERVER = server.jitsi?.server ? server.jitsiServer
 
 # -- Performance settings --
 

--- a/client/imports/jitsi.coffee
+++ b/client/imports/jitsi.coffee
@@ -1,11 +1,13 @@
 'use strict'
 
 import canonical from '/lib/imports/canonical.coffee'
+import { StaticJitsiMeeting } from '/lib/imports/settings.coffee'
 
 export jitsiRoom = (roomType, roomId) ->
   return unless roomId
-  return unless share.settings.JITSI_STATIC_ROOM?
-  return "#{canonical(share.settings.TEAM_NAME)}-#{canonical(share.settings.JITSI_STATIC_ROOM)}" if roomId is '0'
+  if roomId is '0'
+    return unless StaticJitsiMeeting.get()
+    return "#{canonical(share.settings.TEAM_NAME)}-#{StaticJitsiMeeting.get()}"
   "#{canonical(share.settings.TEAM_NAME)}-#{roomType}-#{roomId}"
 
 export default jitsiUrl = (roomType, roomId) ->

--- a/lib/imports/settings.coffee
+++ b/lib/imports/settings.coffee
@@ -44,7 +44,7 @@ class Setting
   ensure: ->
     Settings.upsert @canon,
       $setOnInsert:
-        value: @default
+        value: @convert(@default)
         touched: Date.now()
 
 parse_boolean = (x) ->
@@ -64,6 +64,9 @@ url_matcher = Match.Where (url) ->
   unless u.protocol is 'https:' or u.protocol is 'http:'
     throw new Match.Error "Invalid URL protocol #{u.protocol} in URL #{url}"
   true
+
+path_component_matcher = Match.Where (s) ->
+  /^[-_a-zA-Z0-9]*$/.test(s)
 
 id = (x) -> x
 
@@ -97,6 +100,14 @@ export MaximumMemeLength = new Setting(
   140,
   Match.Integer,
   parseInt
+)
+
+export StaticJitsiMeeting = new Setting(
+  'Static Jitsi Meeting',
+  'The name of the jitsi room to use for the blackboard and callins page',
+  if Meteor.isServer then (Meteor.settings?.jitsi?.staticRoom ? process.env.STATIC_JITSI_ROOM ? '') else '',
+  path_component_matcher,
+  canonical
 )
 
 Object.freeze all_settings

--- a/lib/imports/settings.test.coffee
+++ b/lib/imports/settings.test.coffee
@@ -104,6 +104,27 @@ describe 'settings', ->
           value: 286
           touched: 7
           touched_by: 'torgen'
+    
+    describe 'of path component', ->
+      uuid = '469a2d19-8a0C-4650-8621-7077a6de8ee6'
+      it 'allows uuid', ->
+        impersonating 'torgen', ->
+          settings.StaticJitsiMeeting.set uuid
+        chai.assert.deepEqual settings.Settings.findOne('static_jitsi_meeting'),
+          _id: 'static_jitsi_meeting'
+          value: uuid
+          touched: 7
+          touched_by: 'torgen'
+
+      it 'canonicalizes', ->
+        impersonating 'torgen', ->
+          settings.StaticJitsiMeeting.set 'it\'s ya boy Voynich'
+        chai.assert.deepEqual settings.Settings.findOne('static_jitsi_meeting'),
+          _id: 'static_jitsi_meeting'
+          value: 'its_ya_boy_voynich'
+          touched: 7
+          touched_by: 'torgen'
+
   
   describe 'get', ->
     it 'allows legacy values', ->

--- a/private/installtemplates/etc/codex-common.env.handlebars
+++ b/private/installtemplates/etc/codex-common.env.handlebars
@@ -56,18 +56,15 @@ HTTP_FORWARDED_COUNT=1
 #           This will also be used to generate Jitsi meeting names if jitsi is enabled.
 #           If unset, this defaults to "Codex".
 # whoseGitHub: The hamburger menu has a link to the issues page on GitHub. This controls which fork of the repo the link points at.
-# jitsi: this group governs automatically linked and embedded Jitsi Meet rooms.
-#        Removing this group, or not setting the server setting, means Jitsi
-#        meetings will not be created. Its nested settings are:
-#   server: Which Jitsi server to use. A list of public servers is available at
-#           https://jitsi.github.io/handbook/docs/community-instances
-#   staticRoom: Per-puzzle rooms use the randomly-generated ID of the puzzle,
-#               not its name, meaning they are not guessable. The blackboard and
-#               the callins page do not have IDs, so a consistent non-guessable
-#               meeting name is required for them. (They share this meeting.)
-#               If this isn't set, those pages do not have a meeting, but
-#               puzzles still do.
-METEOR_SETTINGS='{"public":{"teamName": "{{domainname}}", "defaultHost":"{{domainname}}", "whoseGitHub":"Torgen", "jitsi": {"server": "meet.jit.si", "staticRoom": "{{staticroom}}"} } }'
+# jitsiServer: If set, each puzzle will have an embedded Jitsi video chat on it. If not set, no meetings will be created.
+#              A list of public servers is available at https://jitsi.github.io/handbook/docs/community-instances
+METEOR_SETTINGS='{"public":{"teamName": "{{domainname}}", "defaultHost":"{{domainname}}", "whoseGitHub":"Torgen", "jitsiServer": "meet.jit.si" } }'
+
+# The default value to use for the name of the room shared by the blackboard and callins pages. Unlike puzzle pages,
+# which use the randomly-generated ID of the puzzle and thus aren't guessable, both those pages have well-known chat
+# room names. This is an environment variable and not a public setting because public settings are visible even if
+# you're not logged in. This is the default value of a dynamic setting, so it can be changed once the server is running.
+JITSI_STATIC_ROOM="{{staticroom}}"
 
 # The url to the database. You shouldn't need to change these.
 MONGO_OPLOG_URL=mongodb://127.0.0.1:27017/local


### PR DESCRIPTION
This means visitors to the site have to be logged in to receive it, unlike when it was a public setting.