### PR TITLE
Suppress login dialog if no manual action is needed

### DIFF
--- a/client/header.coffee
+++ b/client/header.coffee
@@ -439,6 +439,9 @@ uploadToDriveFolder = share.uploadToDriveFolder = (folder, callback) ->
 ############## nick selection ####################
 
 Template.header_nickmodal_contents.onCreated ->
+  @suppressRender = new ReactiveVar Meteor.loggingIn()
+  @autorun =>
+    @suppressRender.set false unless Meteor.loggingIn()
   # we'd need to subscribe to 'all-nicks' here if we didn't have a permanent
   # subscription to it (in main.coffee)
   this.typeaheadSource = (query,process) =>
@@ -466,6 +469,7 @@ Template.header_nickmodal_contents.onCreated ->
       container.append(gravatar)
 nickInput = new Tracker.Dependency
 Template.header_nickmodal_contents.helpers
+  suppressRender: -> Template.instance().suppressRender.get()
   disabled: ->
     nickInput.depend()
     Meteor.loggingIn() or not $('#nickInput').val()

--- a/header.html
+++ b/header.html
@@ -305,61 +305,65 @@
 </template>
 
 <template name="header_nickmodal_contents">
-  <div class="modal-header">
-    <h3>Login</h3>
-  </div>
-  <div class="modal-body">
-    <form id="nickPick" class="form-horizontal">
-      <div class="control-group" id="passwordInputGroup" data-argument="password">
-        <label class="control-label" for="passwordInput">Team Password</label>
-        <div class="controls">
-          <input type="password" id="passwordInput" autocomplete="password"
-                 inputmode="verbatim" autofocus
-                 placeholder="from listserv or whiteboard" />
-          <span class="help-inline">(same for everyone)</span>
-        </div>
+  {{#unless suppressRender}}
+    <div class="modal show">
+      <div class="modal-header">
+        <h3>Login</h3>
       </div>
-      <div class="control-group" id="nickInputGroup" data-argument="nickname">
-        <label class="control-label" for="nickInput">Nick</label>
-        <div class="controls">
-          <div class="input-prepend">
-            <span class="add-on">@</span>
-            <input type="text" id="nickInput" autocomplete="nickname"
-                    inputmode="verbatim" required
-                    placeholder="nick" maxlength=20/>
+      <div class="modal-body">
+        <form id="nickPick" class="form-horizontal">
+          <div class="control-group" id="passwordInputGroup" data-argument="password">
+            <label class="control-label" for="passwordInput">Team Password</label>
+            <div class="controls">
+              <input type="password" id="passwordInput" autocomplete="password"
+                    inputmode="verbatim" autofocus
+                    placeholder="from listserv or whiteboard" />
+              <span class="help-inline">(same for everyone)</span>
+            </div>
           </div>
-          <span class="help-inline">(1-20 characters)</span>
-        </div>
+          <div class="control-group" id="nickInputGroup" data-argument="nickname">
+            <label class="control-label" for="nickInput">Nick</label>
+            <div class="controls">
+              <div class="input-prepend">
+                <span class="add-on">@</span>
+                <input type="text" id="nickInput" autocomplete="nickname"
+                        inputmode="verbatim" required
+                        placeholder="nick" maxlength=20/>
+              </div>
+              <span class="help-inline">(1-20 characters)</span>
+            </div>
+          </div>
+          <div class="control-group" data-argument="real_name">
+            <label class="control-label" for="nickRealname">Real Name</label>
+            <div class="controls">
+              <input type="text" id="nickRealname" autocomplete="name"
+                      inputmode="latin-name" maxlength=100
+                      placeholder="{{namePlaceholder}}" />
+              <span class="help-inline">(optional)</span>
+            </div>
+          </div>
+          <div class="control-group" data-argument="gravatar">
+            <label class="control-label" for="nickEmail">Email
+                <div class="gravatar"></div></label>
+            <div class="controls">
+              <input type="email" id="nickEmail" autocomplete="email"
+                      placeholder="user@host.org" maxlength=100 />
+              <span class="help-inline">(optional)</span>
+              <span class="help-block">Only used to look up
+              <a href="https://gravatar.com" target="_blank">Gravatar</a></span>
+            </div>
+          </div>
+        <input type="hidden" id="nickSuccess" value="false" />
+        </form>
       </div>
-      <div class="control-group" data-argument="real_name">
-        <label class="control-label" for="nickRealname">Real Name</label>
-        <div class="controls">
-          <input type="text" id="nickRealname" autocomplete="name"
-                  inputmode="latin-name" maxlength=100
-                  placeholder="{{namePlaceholder}}" />
-          <span class="help-inline">(optional)</span>
-        </div>
+      <div class="modal-footer">
+        <span id="loginError" class="warning"></span>
+        <button type="button" class="btn btn-primary bb-submit" disabled="{{disabled}}">
+          {{#if loggingIn}}Logging in...{{else}}Log in{{/if}}
+        </button>
       </div>
-      <div class="control-group" data-argument="gravatar">
-        <label class="control-label" for="nickEmail">Email
-            <div class="gravatar"></div></label>
-        <div class="controls">
-          <input type="email" id="nickEmail" autocomplete="email"
-                  placeholder="user@host.org" maxlength=100 />
-          <span class="help-inline">(optional)</span>
-          <span class="help-block">Only used to look up
-          <a href="https://gravatar.com" target="_blank">Gravatar</a></span>
-        </div>
-      </div>
-    <input type="hidden" id="nickSuccess" value="false" />
-    </form>
-  </div>
-  <div class="modal-footer">
-    <span id="loginError" class="warning"></span>
-    <button type="button" class="btn btn-primary bb-submit" disabled="{{disabled}}">
-      {{#if loggingIn}}Logging in...{{else}}Log in{{/if}}
-    </button>
-  </div>
+    </div>
+  {{/unless}}
 </template>
 
 <template name="header_confirmmodal">

--- a/page.html
+++ b/page.html
@@ -30,9 +30,7 @@ function onGoogleApiLoad() {
       {{> header_confirmmodal}}
     {{/if}}
   {{else}}
-    <div class="modal show">
-      {{> header_nickmodal_contents}}
-    </div>
+    {{> header_nickmodal_contents}}
   {{/if}}
 </body>
 


### PR DESCRIPTION
If it's already logging in when you load the page, e.g. because you were already logged in, don't show a brief flash of the login dialog. (But do show it if the login fails.)