### PR TITLE
Replace video icon in breadcrumbs with pop-out link over video

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -69,6 +69,7 @@ Click here to stay in this meeting instead.{{/if}}">
             <i class="fas fa-thumbtack"></i>
           </a>
           <a href="#" class="bb-jitsi-cap-height {{#if jitsiHeightCapped}}capped{{/if}}" title="Limit jitsi meeting to 50 pixels high"><i class="fas fa-compress-alt"></i></a>
+          <a href="{{jitsiUrl}}" class="bb-pop-jitsi" target="jitsi" title="Open this meeting in another tab"><i class="fas fa-external-link-alt"></i></a>
         </div>
       {{/if}}
     </div>

--- a/client/chat.coffee
+++ b/client/chat.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-import { jitsiRoom } from './imports/jitsi.coffee'
+import jitsiUrl, { jitsiRoom } from './imports/jitsi.coffee'
 import { nickEmail, emailFromNickObject } from './imports/nickEmail.coffee'
 import botuser from './imports/botuser.coffee'
 import canonical from '/lib/imports/canonical.coffee'
@@ -479,6 +479,7 @@ Template.embedded_chat.helpers
       return Math.min 50, sizeWouldBe
     sizeWouldBe
   jitsiPinSet: -> Template.instance().jitsiPinType.get()?
+  jitsiUrl: -> jitsiUrl Session.get('type'), Session.get('id')
   usingJitsiPin: ->
     instance = Template.instance()
     jitsiRoom(instance.jitsiType(), instance.jitsiId()) isnt jitsiRoom(Session.get('type'), Session.get('id'))
@@ -494,6 +495,8 @@ Template.embedded_chat.events
   'click .bb-join-jitsi': (event, template) ->
     reactiveLocalStorage.setItem 'jitsiTabUUID', settings.CLIENT_UUID
     template.jitsiLeft.set false
+  'click .bb-pop-jitsi': (event, template) ->
+    template.leaveJitsi()
   'click .bb-jitsi-pin': (event, template) ->
     template.jitsiPinType.set Session.get 'type'
     template.jitsiPinId.set Session.get 'id'

--- a/header.html
+++ b/header.html
@@ -43,11 +43,6 @@
   <a class="{{../type}}-link {{#if active}}{{#if currentViewIs "info"}}current{{/if}}{{/if}}" href="/{{../type}}/{{../id}}/info"  title="Info">
     <i class="fas fa-info-circle"></i>
   </a>
-  {{#with jitsiUrl}}
-    <a href="{{this}}" target="jitsi" title="Jitsi Video Call">
-      <i class="fas fa-video"></i>
-    </a>
-  {{/with}}
   {{> header_breadcrumb_chat ..}}
 </template>
 


### PR DESCRIPTION
It leaves the meeting before opening the new tab