### PR TITLE
Fix mistakes in Drive v3 migration

### DIFF
--- a/server/imports/drive.coffee
+++ b/server/imports/drive.coffee
@@ -42,7 +42,6 @@ ensurePermissions = (drive, id) ->
   if CODEX_ACCOUNT()?
     perms.push
       # edit permissions to codex account
-      allowFileDiscovery: true
       role: 'writer'
       type: 'user'
       emailAddress: CODEX_ACCOUNT()

--- a/server/imports/drive.coffee
+++ b/server/imports/drive.coffee
@@ -86,7 +86,7 @@ ensure = (drive, name, folder, settings) ->
     doc =
       name: settings.titleFunc name
       mimeType: settings.driveMimeType
-      parents: [id: folder.id]
+      parents: [folder.id]
     doc = (await drive.files.create
       resource: doc
       media:
@@ -127,7 +127,7 @@ ensureFolder = (drive, name, parent) ->
     resource =
       name: name
       mimeType: GDRIVE_FOLDER_MIME_TYPE
-    resource.parents = [id: parent] if parent
+    resource.parents = [parent] if parent
     resource = (await drive.files.create(resource: resource)).data
   # give the new folder the right permissions
   {

--- a/server/imports/drive.coffee
+++ b/server/imports/drive.coffee
@@ -18,6 +18,8 @@ XLSX_MIME_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sh
 MAX_RESULTS = 200
 SPREADSHEET_TEMPLATE = Assets.getBinary 'spreadsheet-template.xlsx'
 
+PERMISSION_LIST_FIELDS = ("permissions/#{x}" for x in ['role', 'type', 'emailAddress', 'allowFileDiscovery']).join()
+
 quote = (str) -> "'#{str.replace(/([\'\\])/g, '\\$1')}'"
 
 samePerm = (p, pp) ->
@@ -45,7 +47,7 @@ ensurePermissions = (drive, id) ->
       role: 'writer'
       type: 'user'
       emailAddress: CODEX_ACCOUNT()
-  resp = (await drive.permissions.list fileId: id).data
+  resp = (await drive.permissions.list({fileId: id, fields: PERMISSION_LIST_FIELDS})).data
   ps = []
   perms.forEach (p) ->
     # does this permission already exist?

--- a/server/imports/drive.test.coffee
+++ b/server/imports/drive.test.coffee
@@ -17,6 +17,8 @@ EVERYONE_PERM =
   role: 'writer'
   type: 'anyone'
 
+PERMISSION_LIST_FIELDS = "permissions/role,permissions/type,permissions/emailAddress,permissions/allowFileDiscovery"
+
 defaultPerms =  [EVERYONE_PERM, OWNER_PERM]
 
 describe 'drive', ->
@@ -69,6 +71,7 @@ describe 'drive', ->
         mimeType: 'application/vnd.google-apps.folder'
       permissions.expects('list').withArgs sinon.match
         fileId: 'hunt'
+        fields: PERMISSION_LIST_FIELDS
       .resolves data: permissions: []
       perms.forEach (perm) ->
         permissions.expects('create').withArgs sinon.match
@@ -90,6 +93,7 @@ describe 'drive', ->
         mimeType: 'application/vnd.google-apps.folder'
       permissions.expects('list').withArgs sinon.match
         fileId: 'uploads'
+        fields: PERMISSION_LIST_FIELDS
       .resolves data: permissions: []
       perms.forEach (perm) ->
         permissions.expects('create').withArgs sinon.match
@@ -139,6 +143,7 @@ describe 'drive', ->
             parents: ['hunt']
           permissions.expects('list').withArgs sinon.match
             fileId: 'newpuzzle'
+            fields: PERMISSION_LIST_FIELDS
           .resolves data: permissions: []
           perms.forEach (perm) ->
             permissions.expects('create').withArgs sinon.match
@@ -165,6 +170,7 @@ describe 'drive', ->
             parents: ['newpuzzle']
           permissions.expects('list').withArgs sinon.match
             fileId: 'newsheet'
+            fields: PERMISSION_LIST_FIELDS
           .resolves data: permissions: []
           perms.forEach (perm) ->
             permissions.expects('create').withArgs sinon.match
@@ -191,6 +197,7 @@ describe 'drive', ->
             parents: ['newpuzzle']
           permissions.expects('list').withArgs sinon.match
             fileId: 'newdoc'
+            fields: PERMISSION_LIST_FIELDS
           .resolves data: permissions: []
           perms.forEach (perm) ->
             permissions.expects('create').withArgs sinon.match
@@ -211,6 +218,7 @@ describe 'drive', ->
           ]
           permissions.expects('list').withArgs sinon.match
             fileId: 'newpuzzle'
+            fields: PERMISSION_LIST_FIELDS
           .resolves data: permissions: defaultPerms
           files.expects('list').withArgs sinon.match
             pageSize: 1
@@ -223,6 +231,7 @@ describe 'drive', ->
           ]
           permissions.expects('list').withArgs sinon.match
             fileId: 'newsheet'
+            fields: PERMISSION_LIST_FIELDS
           .resolves data: permissions: defaultPerms
           files.expects('list').withArgs sinon.match
             pageSize: 1
@@ -235,6 +244,7 @@ describe 'drive', ->
           ]
           permissions.expects('list').withArgs sinon.match
             fileId: 'newdoc'
+            fields: PERMISSION_LIST_FIELDS
           .resolves data: permissions: defaultPerms
           drive.createPuzzle 'New Puzzle'
 

--- a/server/imports/drive.test.coffee
+++ b/server/imports/drive.test.coffee
@@ -7,7 +7,6 @@ import { Drive } from './drive.coffee'
 import { Readable } from 'stream'
 
 OWNER_PERM =
-  allowFileDiscovery: true
   role: 'writer'
   type: 'user'
   emailAddress: 'foo@bar.baz'
@@ -84,7 +83,7 @@ describe 'drive', ->
         resource:
           name: 'Ringhunters Uploads'
           mimeType: 'application/vnd.google-apps.folder'
-          parents: sinon.match.some sinon.match id: 'hunt'
+          parents: sinon.match.some sinon.match  'hunt'
       .resolves data:
         id: 'uploads'
         name: 'Ringhunters Uploads'
@@ -118,7 +117,7 @@ describe 'drive', ->
           id: 'uploads'
           name: 'Ringhunters Uploads'
           mimeType: 'application/vnd.google-apps.folder'
-          parents: [id: 'hunt']
+          parents: ['hunt']
         ]
         drive = new Drive api
 
@@ -132,12 +131,12 @@ describe 'drive', ->
             resource:
               name: 'New Puzzle'
               mimeType: 'application/vnd.google-apps.folder'
-              parents: sinon.match.some sinon.match id: 'hunt'
+              parents: sinon.match.some sinon.match  'hunt'
           .resolves data:
             id: 'newpuzzle'
             name: 'New Puzzle'
             mimeType: 'application/vnd.google-apps.folder'
-            parents: [id: 'hunt']
+            parents: ['hunt']
           permissions.expects('list').withArgs sinon.match
             fileId: 'newpuzzle'
           .resolves data: permissions: []
@@ -153,7 +152,7 @@ describe 'drive', ->
           sheet = sinon.match
             name: 'Worksheet: New Puzzle'
             mimeType: 'application/vnd.google-apps.spreadsheet'
-            parents: sinon.match.some sinon.match id: 'newpuzzle'
+            parents: sinon.match.some sinon.match  'newpuzzle'
           files.expects('create').withArgs sinon.match
             resource: sheet
             media: sinon.match
@@ -163,7 +162,7 @@ describe 'drive', ->
             id: 'newsheet'
             name: 'Worksheet: New Puzzle'
             mimeType: 'application/vnd.google-apps.spreadsheet'
-            parents: [id: 'newpuzzle']
+            parents: ['newpuzzle']
           permissions.expects('list').withArgs sinon.match
             fileId: 'newsheet'
           .resolves data: permissions: []
@@ -179,7 +178,7 @@ describe 'drive', ->
           doc = sinon.match
             name: 'Notes: New Puzzle'
             mimeType: 'application/vnd.google-apps.document'
-            parents: sinon.match.some sinon.match id: 'newpuzzle'
+            parents: sinon.match.some sinon.match  'newpuzzle'
           files.expects('create').withArgs sinon.match
             resource: doc
             media: sinon.match
@@ -189,7 +188,7 @@ describe 'drive', ->
             id: 'newdoc'
             name: 'Worksheet: New Puzzle'
             mimeType: 'application/vnd.google-apps.document'
-            parents: [id: 'newpuzzle']
+            parents: ['newpuzzle']
           permissions.expects('list').withArgs sinon.match
             fileId: 'newdoc'
           .resolves data: permissions: []
@@ -208,7 +207,7 @@ describe 'drive', ->
             id: 'newpuzzle'
             name: 'New Puzzle'
             mimeType: 'application/vnd.google-apps.folder'
-            parents: [id: 'hunt']
+            parents: ['hunt']
           ]
           permissions.expects('list').withArgs sinon.match
             fileId: 'newpuzzle'
@@ -220,7 +219,7 @@ describe 'drive', ->
             id: 'newsheet'
             name: 'Worksheet: New Puzzle'
             mimeType: 'application/vnd.google-apps.spreadsheet'
-            parents: [id: 'newpuzzle']
+            parents: ['newpuzzle']
           ]
           permissions.expects('list').withArgs sinon.match
             fileId: 'newsheet'
@@ -232,7 +231,7 @@ describe 'drive', ->
             id: 'newdoc'
             name: 'Notes: New Puzzle'
             mimeType: 'application/vnd.google-apps.document'
-            parents: [id: 'newpuzzle']
+            parents: ['newpuzzle']
           ]
           permissions.expects('list').withArgs sinon.match
             fileId: 'newdoc'
@@ -257,7 +256,7 @@ describe 'drive', ->
             id: 'newpuzzle'
             name: 'New Puzzle'
             mimeType: 'application/vnd.google-apps.folder'
-            parents: [id: 'hunt']
+            parents: ['hunt']
           ]
           files.expects('list').withArgs sinon.match
             pageSize: 1
@@ -266,7 +265,7 @@ describe 'drive', ->
             id: 'newsheet'
             name: 'Worksheet: New Puzzle'
             mimeType: 'application/vnd.google-apps.spreadsheet'
-            parents: [id: 'newpuzzle']
+            parents: ['newpuzzle']
           ]
           files.expects('list').withArgs sinon.match
             pageSize: 1
@@ -275,7 +274,7 @@ describe 'drive', ->
             id: 'newdoc'
             name: 'Notes: New Puzzle'
             mimeType: 'application/vnd.google-apps.document'
-            parents: [id: 'newpuzzle']
+            parents: ['newpuzzle']
           ]
           chai.assert.include drive.findPuzzle('New Puzzle'),
             id: 'newpuzzle'
@@ -287,12 +286,12 @@ describe 'drive', ->
           id: 'newpuzzle'
           name: 'New Puzzle'
           mimeType: 'application/vnd.google-apps.folder'
-          parents: [id: 'hunt']
+          parents: ['hunt']
         item2 =
           id: 'oldpuzzle'
           name: 'Old Puzzle'
           mimeType: 'application/vnd.google-apps.folder'
-          parents: [id: 'hunt']
+          parents: ['hunt']
         files.expects('list').withArgs sinon.match 
           q: 'mimeType=\'application/vnd.google-apps.folder\' and \'hunt\' in parents'
           pageSize: 200
@@ -336,7 +335,7 @@ describe 'drive', ->
             id: 'newsheet'
             name: 'Worksheet: New Puzzle'
             mimeType: 'application/vnd.google-apps.spreadsheet'
-            parents: [id: 'newpuzzle']
+            parents: ['newpuzzle']
           ]
           nextPageToken: 'token'
         files.expects('delete').withArgs sinon.match
@@ -351,7 +350,7 @@ describe 'drive', ->
             id: 'newdoc'
             name: 'Notes: New Puzzle'
             mimeType: 'application/vnd.google-apps.document'
-            parents: [id: 'newpuzzle']
+            parents: ['newpuzzle']
           ]
         files.expects('delete').withArgs sinon.match
           fileId: 'newdoc'


### PR DESCRIPTION
Need to specify fields in permissions.list for emailAddress to be present.
Parents is a list of strings, not a list of {id: string}.
File discovery isn't allowed to be set when sharing a file with a person.