### PR TITLE
Micro header

### DIFF
--- a/blackboard.less
+++ b/blackboard.less
@@ -40,7 +40,7 @@
           border-radius: @radius;
 }
 
-@navbar-height: 101px; /* was 69px */
+@navbar-height: 40px;
 
 body {
   background: url('/img/grid_noise.png');
@@ -78,9 +78,11 @@ body {
     }
   }
 }
-.darkMode a:not(.btn) {
-  color: hsl(200,100%,80%);
-  &:hover {color: hsl(200.2,100%,95.1%);}
+.darkMode {
+  a:not(.btn), a.btn-link {
+    color: hsl(200,100%,80%);
+    &:hover {color: hsl(200.2,100%,95.1%);}
+  }
 }
 // For mobile devices which actually support native emojis:
 body.has-emojis {
@@ -129,10 +131,6 @@ body.has-emojis {
       }
     }
   }
-}
-
-.bb-chat-messages {
-  padding-top: 40px; /* allow space for breadcrumbs in navbar */
 }
 .bb-puzzleround {
   padding-right: 2px; padding-left: 2px;
@@ -206,7 +204,7 @@ body.has-emojis {
   tbody tr:nth-child(even), thead tr { background-color: var(--barely-darker);}
 }
 .bb-chat-messages {
-  margin-bottom: 26px; /* 41px navbar - 15px padding on #bb-body */
+  margin-bottom: 41px; /* 41px navbar - 15px padding on #bb-body */
 }
 .bb-chat-callin, .bb-puzzleround {
   .bb-summon-form {
@@ -221,15 +219,13 @@ body.has-emojis {
 
 #bb-body {
   padding-top: @navbar-height;
-  &.compactHeader { padding-top: @navbar-height - 21px; }
 }
 
 .bb-buttonbar {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   text-align: right;
   padding-right: 5px;
-  .compactHeader & { flex-direction: row; }
   .btn-group { text-align: left; }
   .btn-toolbar { margin-top: 0; margin-bottom: 0; }
   .tooltip-inner {
@@ -624,16 +620,12 @@ input[type=color] {
   .navbar-fixed-bottom { margin-top: 0; }
   .navbar-fixed-top {
     padding: 0;
-    .navbar-inner { padding: 0px; }
   }
   #bb-content > .navbar-fixed-top {
     position: absolute;
   }
   #messages {
-    padding-top: @navbar-height - 20px;
-    .compactHeader & {
-      padding-top: 22px;
-    }
+    padding-top: @navbar-height;
     /* Need this amount of specificity to override .row-fluid rule. */
     #bb-body .bb-splitter & { padding-top: 0px; }
   }
@@ -643,7 +635,7 @@ input[type=color] {
     padding-top: 0px;
     padding-bottom: 0;
     #bb-content > #bb-blackboard {
-      padding-top: @navbar-height - 40px;
+      padding-top: 0px;
     }
   }
   .bb-hide-status {
@@ -712,7 +704,7 @@ input[type=color] {
     display: none;
   }
   #bb-body #bb-content > #bb-blackboard {
-    padding-top: @navbar-height - 40px;
+    padding-top: 0px;
   }
 }
 

--- a/blackboard.less
+++ b/blackboard.less
@@ -261,6 +261,7 @@ body.has-emojis {
     font-size:14px;
     line-height:16px;
     height:16px;
+    .badge { line-height:12px; }
   }
   .rooms{
     width: min-content;

--- a/blackboard.less
+++ b/blackboard.less
@@ -246,30 +246,41 @@ body.has-emojis {
 .bb-breadcrumbs .tooltip-inner { .bb-buttonbar .tooltip-inner; }
 .bb-breadcrumbs .tooltip.bottom .tooltip-arrow { .bb-buttonbar .tooltip.bottom .tooltip-arrow; }
 
-.bb-lastchat, .bb-lastupdate {
+.bb-lastchat {
   margin-bottom: @vert-padding;
   margin-top: @vert-padding;
-  padding: 0 (15px + @right-size) 0 (14px + @left-size);
-  & > .left { margin-left: (-@left-size); }
-  & > .right { margin-right: (-@right-size);
-                text-align: right;
-                a[title], a[data-original-title] { position:relative; }
-    .bb-pop-out { font-size: 80%; }
+  display: flex;
+  flex-flow: row nowrap;
+  flex-grow: 1;
+  flex-shrink: 1;
+  overflow: hidden;
+  .messageRow {
+    .ellipsis;
+    margin-top: 0;
+    margin-bottom: 0;
+    font: 90%;
+    line-height: 1.25;
   }
-  &, .messageRow { .ellipsis; }
-}
-.bb-lastchat .messageRow {
-  margin-top: 0;
-  margin-bottom: 0;
-  font: 90%;
-  line-height: 1.25;
-}
-.bb-lastchat > .right { line-height: 16px; }
-.bb-lastchat, .bb-lastupdate {
+  .rooms{
+    width: min-content;
+    white-space: initial;
+    font-weight: bold;
+    font-size: 32px;
+    line-height: 32px;
+    padding-left: 15px;
+    padding-right: 8px;
+    display: flex;
+    flex-direction: column-reverse;
+    color: white; /* not --text-color; header is always dark. */
+  }
+  .chats {
+    display: flex;
+    flex-direction: column-reverse;
+    .ellipsis;
+    flex-grow: 1;
+    flex-shrink: 1;
+  }
   .timestamp { color: #555; }
-}
-.bb-lastupdate {
-  .comma-list { text-transform: uppercase; }
 }
 .bb-chat-presence {
   .ellipsis;

--- a/blackboard.less
+++ b/blackboard.less
@@ -258,8 +258,8 @@ body.has-emojis {
     .ellipsis;
     margin-top: 0;
     margin-bottom: 0;
-    font: 90%;
-    line-height: 1.25;
+    font-size:14px;
+    line-height:16px;
   }
   .rooms{
     width: min-content;

--- a/blackboard.less
+++ b/blackboard.less
@@ -260,6 +260,7 @@ body.has-emojis {
     margin-bottom: 0;
     font-size:14px;
     line-height:16px;
+    height:16px;
   }
   .rooms{
     width: min-content;

--- a/blackboard.less
+++ b/blackboard.less
@@ -29,7 +29,7 @@
 
 .bb-abbrev-when-narrow::before {
   content: attr(data-full);
-  @media (max-width: 767px)  {
+  @media (max-width: 1200px)  {
     content: attr(data-abbrev);
   }
 }
@@ -270,12 +270,12 @@ body.has-emojis {
     font-size: 32px;
     line-height: 32px;
     padding-left: 15px;
-    padding-right: 8px;
     display: flex;
     flex-direction: column-reverse;
     color: white; /* not --text-color; header is always dark. */
   }
   .chats {
+    padding-left: 8px;
     display: flex;
     flex-direction: column-reverse;
     .ellipsis;
@@ -622,7 +622,8 @@ input[type=color] {
 
 /* Desktop large
 ------------------------- */
-@media (min-width: 1200px) {
+@media (max-width: 1440px) {
+  .nav li .bb-omit-when-narrow { display: none; }
 }
 
 /* Desktop
@@ -633,9 +634,7 @@ input[type=color] {
   .navbar-fixed-bottom { margin-top: 0; }
   .navbar-fixed-top {
     padding: 0;
-  }
-  #bb-content > .navbar-fixed-top {
-    position: absolute;
+    position: fixed;
   }
   #messages {
     padding-top: @navbar-height;
@@ -645,7 +644,6 @@ input[type=color] {
   .bb-puzzleround { padding-top: 0 !important; }
   .bb-chat-footer { margin-left: -20px; margin-right: -20px; }
   #bb-body {
-    padding-top: 0px;
     padding-bottom: 0;
     #bb-content > #bb-blackboard {
       padding-top: 0px;
@@ -664,21 +662,6 @@ input[type=color] {
   /* fixup fullHeight stuff */
   html.fullHeight {
     body { padding-right: 0; padding-left: 0; }
-    #bb-content {
-      & > .bb-topbar {
-        position: absolute;
-        top: 0;
-        left: 0; right: 0; width: auto;
-        padding: 0;
-        margin: 0;
-      }
-      & > .bb-puzzleround {
-        position: absolute;
-        left: 20px; right: 20px; width: auto;
-        top: 69px; bottom: 3px; height: auto;
-        padding-top: 0;
-      }
-    }
   }
 }
 
@@ -719,6 +702,7 @@ input[type=color] {
   #bb-body #bb-content > #bb-blackboard {
     padding-top: 0px;
   }
+  #bb-body .bb-left-content .bb-pop-full-menu { right: 16px;}
 }
 
 @media (min-width: 481px) and (max-width: 980px) {

--- a/chat.html
+++ b/chat.html
@@ -7,15 +7,6 @@
       {{> puzzle_callin_modal}}
       {{> puzzle_summon_modal}}
     {{/with}}
-  <div class="bb-chat-callin {{#if solved}}solved{{/if}}">
-    {{#if solved}}Solved
-    {{else}}
-      {{#with object}}
-        {{> puzzle_callin_button}}
-        {{> puzzle_summon_button}}
-      {{/with}}
-    {{/if}}
-  </div>
   {{/if}}
   <div class="navbar navbar-inverse navbar-fixed-bottom bb-chat-footer">
     <div class="navbar-inner">

--- a/chat.less
+++ b/chat.less
@@ -23,9 +23,6 @@
     .bb-tiny-chat-messages;
   }
 }
-.compactHeader .bb-chat-messages {
-  padding-top: 20px;
-}
 .bb-chat-messages {
   @chat-arrow-size: 6px;
   @chat-arrow-height: 15px;

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -8,7 +8,6 @@ import { reactiveLocalStorage } from './imports/storage.coffee'
 model = share.model # import
 settings = share.settings # import
 
-NAVBAR_HEIGHT = 73 # keep in sync with @navbar-height in blackboard.less
 SOUND_THRESHOLD_MS = 30*1000 # 30 seconds
 
 blackboard = {} # store page global state

--- a/client/header.coffee
+++ b/client/header.coffee
@@ -535,7 +535,7 @@ Template.header_lastchats.helpers
     else
       settings.GENERAL_ROOM_NAME
   roomicon: ->
-    if @ is 'oplog/0'
+    query = if Session.equals('room_name', 'general/0')
       'newspaper'
     else
       'comments'

--- a/client/header.coffee
+++ b/client/header.coffee
@@ -140,10 +140,6 @@ Template.registerHelper 'pretty_ts', (args) ->
 
 ############## log in/protect/mute panel ####################
 Template.header_loginmute.helpers
-  volumeIcon: ->
-    if 'true' is reactiveLocalStorage.getItem 'mute' then 'fa-volume-mute' else 'fa-volume-up'
-  volumeTitle: ->
-    if 'true' is reactiveLocalStorage.getItem 'mute' then 'Muted' else 'Click to mute sound effects'
   sessionNick: -> # TODO(torgen): replace with currentUser
     user = Meteor.user()
     return unless user?
@@ -162,8 +158,6 @@ Template.header_loginmute.events
     share.Router.navigate "/edit", {trigger: true}
   "click .bb-protect": (event, template) ->
     share.Router.navigate "/", {trigger: true}
-  'click button.mute': (event, template) ->
-    reactiveLocalStorage.setItem 'mute', 'true' isnt reactiveLocalStorage.getItem 'mute'
 
 Template.connection_button.helpers
   connectStatus: Meteor.status
@@ -519,65 +513,3 @@ confirmationDialog = share.confirmationDialog = (options) ->
   Template.header_confirmmodal_contents.options = -> options
   Template.header_confirmmodal_contents.cancel = true
   Session.set 'confirmModalVisible', (options or Object.create(null))
-
-OPLOG_COLLAPSE_LIMIT = 10
-
-############## operation log in header ####################
-Template.header_lastupdates.helpers
-  lastupdates: ->
-    ologs = model.Messages.find {room_name: "oplog/0", dawn_of_time: $ne: true}, \
-          {sort: [["timestamp","desc"]], limit: OPLOG_COLLAPSE_LIMIT}
-    ologs = ologs.fetch()
-    # now look through the entries and collect similar logs
-    # this way we can say "New puzzles: X, Y, and Z" instead of just
-    # "New Puzzle: Z"
-    return '' unless ologs && ologs.length
-    message = [ ologs[0] ]
-    for ol in ologs[1..]
-      if ol.body is message[0].body and ol.type is message[0].type
-        message.push ol
-      else
-        break
-    type = ''
-    if message[0].id
-      type = ' ' + model.pretty_collection(message[0].type) + \
-        (if message.length > 1 then 's ' else ' ')
-    uniq = (array) ->
-      seen = Object.create(null)
-      ((seen[o.id]=o) for o in array when not (o.id of seen))
-    return {
-      timestamp: message[0].timestamp
-      message: message[0].body + type
-      nick: message[0].nick
-      objects: uniq({type:m.type,id:m.id} for m in message)
-    }
-
-# subscribe when this template is in use/unsubscribe when it is destroyed
-Template.header_lastupdates.onCreated ->
-  this.autorun =>
-    this.subscribe 'recent-messages', 'oplog/0', OPLOG_COLLAPSE_LIMIT
-# add tooltip to 'more' links
-do ->
-  for t in ['header_lastupdates', 'header_lastchats']
-    Template[t].onRendered ->
-      $(this.findAll('.right a[title]')).tooltip placement: 'left'
-
-RECENT_GENERAL_LIMIT = 2
-
-############## chat log in header ####################
-Template.header_lastchats.helpers
-  lastchats: ->
-    m = model.Messages.find {
-      room_name: "general/0", system: {$ne: true}, bodyIsHtml: {$ne: true}
-    }, {sort: [["timestamp","desc"]], limit: RECENT_GENERAL_LIMIT}
-    m = m.fetch().reverse()
-    return m
-  msgbody: ->
-    if this.bodyIsHtml then new Spacebars.SafeString(this.body) else this.body
-  roomname: -> settings.GENERAL_ROOM_NAME
-
-# subscribe when this template is in use/unsubscribe when it is destroyed
-Template.header_lastchats.onCreated ->
-  return if settings.BB_DISABLE_RINGHUNTERS_HEADER
-  @autorun =>
-    @subscribe 'recent-header-messages'

--- a/client/main.coffee
+++ b/client/main.coffee
@@ -52,10 +52,6 @@ Template.registerHelper 'linkify', (contents) ->
   contents = chat.convertURLsToLinksAndImages(UI._escape(contents))
   return new Spacebars.SafeString(contents)
 
-Template.registerHelper 'compactHeader', ->
-  Session.equals('currentPage', 'chat') or
-  (Session.equals('type', 'general') and Session.equals('id', '0'))
-
 Template.registerHelper 'teamName', -> settings.TEAM_NAME
 
 Template.registerHelper 'namePlaceholder', -> settings.NAME_PLACEHOLDER

--- a/client/main.coffee
+++ b/client/main.coffee
@@ -2,6 +2,7 @@
 
 import { gravatarUrl, nickHash, md5 } from './imports/nickEmail.coffee'
 import abbrev from '../lib/imports/abbrev.coffee'
+import canonical from '/lib/imports/canonical.coffee'
 import { human_readable, abbrev as ctabbrev } from '../lib/imports/callin_types.coffee'
 import { mechanics } from '../lib/imports/mechanics.coffee'
 import { reactiveLocalStorage } from './imports/storage.coffee'
@@ -32,6 +33,7 @@ do -> for v in ['currentPage']
 Template.registerHelper 'abbrev', abbrev
 Template.registerHelper 'callinType', human_readable
 Template.registerHelper 'callinTypeAbbrev', ctabbrev
+Template.registerHelper 'canonical', canonical
 Template.registerHelper 'currentPageEquals', (arg) ->
   # register a more precise dependency on the value of currentPage
   Session.equals 'currentPage', arg

--- a/client/options_dropdown.coffee
+++ b/client/options_dropdown.coffee
@@ -20,6 +20,7 @@ Template.registerHelper 'hideSolvedMeta', -> 'true' is reactiveLocalStorage.getI
 Template.registerHelper 'hideStatus', -> 'true' is reactiveLocalStorage.getItem 'hideStatus'
 Template.registerHelper 'stuckToTop', -> 'true' is reactiveLocalStorage.getItem 'stuckToTop'
 Template.registerHelper 'noBot', -> 'true' is reactiveLocalStorage.getItem 'nobot'
+Template.registerHelper 'sfxMute', -> 'true' is reactiveLocalStorage.getItem 'mute'
 Template.registerHelper 'hideOldPresence', -> 'true' is reactiveLocalStorage.getItem 'hideOldPresence'
 
 Template.options_dropdown.helpers
@@ -47,6 +48,8 @@ Template.options_dropdown.events
     reactiveLocalStorage.setItem 'stuckToTop', event.target.checked
   'change .bb-bot-mute input': (event, template) ->
     reactiveLocalStorage.setItem 'nobot', event.target.checked
+  'change .bb-sfx-mute input': (event, template) ->
+    reactiveLocalStorage.setItem 'mute', event.target.checked
   'change .bb-hide-old-presence input': (event, template) ->
     reactiveLocalStorage.setItem 'hideOldPresence', event.target.checked
   'change .bb-start-video-muted input': (event, template) ->

--- a/favorite.less
+++ b/favorite.less
@@ -1,6 +1,7 @@
 .bb-favorite-button {
   position: relative;
   display: inline-block;
+  cursor: pointer;
   &::before, &::after {
     font-family: "Font Awesome 5 Free";
     content: "\f004";

--- a/header.html
+++ b/header.html
@@ -139,6 +139,7 @@
     {{> Template.dynamic template=crumb_template}}
   {{/each}}
   <li class="fill">
+    {{> header_lastchats "oplog/0"}}
   {{#if currentPageEquals "chat"}}
     {{> chat_header }}
   {{/if}}
@@ -219,6 +220,30 @@
           class="{{connectStatus.status}} btn {{style}}">
     <span class="bb-statuslight"></span>
   </button>
+</template>
+
+<template name="header_lastchats">
+<!-- Last chat bar -->
+  <div class="bb-lastchat">
+    <div class="rooms fas fa-{{roomicon}}" title={{roomname}}>
+    </div>
+    <div class="chats">
+    {{#each lastchats}}
+    <p class="messageRow">
+    <span class="timestamp">{{pretty_ts timestamp}}</span>
+    {{#if oplog}}
+      {{msgbody}} {{link id}} {{#if nick}} (<strong title="{{nickOrName nick}}">{{nick}}</strong>){{/if}}
+    {{else if action}}
+      <strong title="{{nickOrName nick}}">{{nick}}</strong> {{msgbody}}
+    {{else}}
+      <strong title="{{nickOrName nick}}">{{nick}}:</strong>
+      {{#if to}}/msg <span title="{{nickOrName to}}">{{to}}</span>{{/if}}
+      {{msgbody}}
+    {{/if}}
+    </p>
+    {{/each}}
+    </div>
+  </div>
 </template>
 
 <template name="header_nickmodal_contents">

--- a/header.html
+++ b/header.html
@@ -165,7 +165,8 @@
 
 <template name="header_breadcrumbs_unsolved_buttons">
 {{#unless solved}}
-{{> puzzle_callin_button}}{{> puzzle_summon_button}}
+{{> puzzle_callin_button}}
+{{> puzzle_summon_button}}
 {{/unless}}
 </template>
 

--- a/header.html
+++ b/header.html
@@ -193,11 +193,11 @@
     </div>
   </div>
   </li>
-  <li class="dropdown">
+  <li class="dropdown" id="bb-avatar-dropdown">
     {{#if sessionNick}}
       <a class="dropdown-toggle"
          data-toggle="dropdown" href="#">
-       {{>gravatar nick=sessionNick.canon size=16}}
+       {{>gravatar nick=sessionNick.canon size=24}}
        <span class="caret"></span>
       </a>
       <ul class="dropdown-menu pull-right">

--- a/header.html
+++ b/header.html
@@ -226,7 +226,7 @@
 <template name="header_lastchats">
 <!-- Last chat bar -->
   <div class="bb-lastchat">
-    <div class="rooms fas fa-{{roomicon}}" title={{roomname}}>
+    <div class="bb-omit-when-narrow rooms fas fa-{{roomicon}}" title={{roomname}}>
     </div>
     <div class="chats">
     {{#each lastchats}}

--- a/header.html
+++ b/header.html
@@ -139,7 +139,11 @@
     {{> Template.dynamic template=crumb_template}}
   {{/each}}
   <li class="fill">
-    {{> header_lastchats "oplog/0"}}
+    {{#if generalChat}}
+      {{> header_lastchats "oplog/0"}}
+    {{else}}
+      {{>header_lastchats_switcher}}
+    {{/if}}
   {{#if currentPageEquals "chat"}}
     {{> chat_header }}
   {{/if}}
@@ -225,7 +229,7 @@
 
 <template name="header_lastchats">
 <!-- Last chat bar -->
-  <div class="bb-lastchat">
+  <div class="bb-lastchat" id="bb-lastchat-{{canonical this}}">
     <div class="rooms fas fa-{{roomicon}}" title={{roomname}}>
     </div>
     <div class="chats">
@@ -244,6 +248,13 @@
     </p>
     {{/each}}
     </div>
+  </div>
+</template>
+
+<template name="header_lastchats_switcher">
+  <div class="bb-lastchat-switcher {{#if oplog}}oplog{{/if}}">
+    {{> header_lastchats "general/0"}}
+    {{> header_lastchats "oplog/0"}}
   </div>
 </template>
 

--- a/header.html
+++ b/header.html
@@ -1,13 +1,6 @@
 <template name="header">
 
 <div class="navbar navbar-inverse navbar-fixed-top bb-topbar">
-  <div class="navbar-inner">
-    {{> header_loginmute}}
-    {{> header_lastupdates}}
-    {{#unless compactHeader}}
-      {{> header_lastchats}}
-    {{/unless}}
-  </div>
   {{> header_breadcrumbs}}
 </div>
 </template>
@@ -150,28 +143,20 @@
     {{> chat_header }}
   {{/if}}
   </li>
-  {{#if currentPageEquals "round"}}
-    {{> header_breadcrumbs_unsolved_buttons round}}
-  {{else if currentPageEquals "puzzle"}}
-    {{> header_breadcrumbs_unsolved_buttons puzzle}}
-  {{/if}}
   {{#if drive}}
     {{#if picker}}
 <li class="bb-drive-buttons">
+  <div class="btn-group">
   <button type="button"
           class="bb-upload-file btn btn-inverse">
     <i class="fas fa-file-upload"></i><span class="bb-omit-when-narrow"> Upload file</span>
   </button>
+  </div>
 </li>
     {{/if}}
-<li class="bb-drive-buttons">
-  <span>
-  <a class="bb-drive-link btn btn-inverse"
-     title="Open Drive Folder"
-     target="_blank"
-     href="{{drive_link drive}}"><i class="fab fa-google-drive"></i></a></span>
-</li>
   {{/if}}
+<li class="divider-vertical"></li>
+{{> header_loginmute}}
 </ul>
 <div class="fill"></div>
 </div>
@@ -179,40 +164,14 @@
 
 <template name="header_breadcrumbs_unsolved_buttons">
 {{#unless solved}}
-<li class="bb-drive-buttons">
 {{> puzzle_callin_button}}{{> puzzle_summon_button}}
-</li>
 {{/unless}}
 </template>
 
 <template name="header_loginmute">
+  <li>
 <!-- login/mute buttons -->
-  <div class="bb-buttonbar pull-right">
-   <div>
-    {{#if sessionNick}}
-     <div class="btn-group{{#if compactHeader}} bb-login{{/if}}">
-      <a class="btn btn-small btn-inverse dropdown-toggle"
-         data-toggle="dropdown" href="#">
-       {{>gravatar nick=sessionNick.canon size=16}}
-       {{#if sessionNick.realname}}
-         {{sessionNick.realname}}
-       {{else}}
-         {{sessionNick.name}}
-       {{/if}}
-       <span class="caret"></span>
-      </a>
-      <ul class="dropdown-menu pull-right">
-       <li><a href="#" class="bb-logout"><i class="fas fa-sign-out-alt"></i> Log out</a></li>
-      </ul>
-     </div>
-    {{else}}
-    <button class="btn btn-small btn-inverse bb-login">
-     <i class="fas fa-user"></i>
-     Log in to {{#if currentPageEquals "chat"}}chat{{else}}edit{{/if}}
-    </button>
-    {{/if}}
-   </div>
-   <div class="btn-toolbar">
+  <div class="bb-buttonbar">
 {{#if currentPageEquals "blackboard"}}
     <div class="btn-group">
      <button title="Protect page" data-canEdit="false"
@@ -228,13 +187,31 @@
     {{> options_dropdown}}
 {{/if}}
     <div class="btn-group">
-     <button title="{{volumeTitle}}" class="mute btn btn-small btn-inverse">
-      <span class="fas {{volumeIcon}}"></span>
-     </button>
      {{> connection_button style="btn-small btn-inverse"}}
     </div>
-   </div>
   </div>
+  </li>
+  <li class="dropdown">
+    {{#if sessionNick}}
+      <a class="dropdown-toggle"
+         data-toggle="dropdown" href="#">
+       {{>gravatar nick=sessionNick.canon size=16}}
+       <span class="caret"></span>
+      </a>
+      <ul class="dropdown-menu pull-right">
+        <li class="disabled"><a name="nickname">Nickname: {{sessionNick.name}}</a></li>
+        {{#if sessionNick.realname}}
+          <li class="disabled"><a name="realname">Real name: {{sessionNick.realname}}</a></li>
+        {{/if}}
+        <li><a href="#" class="bb-logout"><i class="fas fa-sign-out-alt"></i> Log out</a></li>
+      </ul>
+    {{else}}
+    <button class="btn btn-small btn-inverse bb-login">
+     <i class="fas fa-user"></i>
+     Log in to {{#if currentPageEquals "chat"}}chat{{else}}edit{{/if}}
+    </button>
+    {{/if}}
+  </li>
 </template>
 
 <template name="connection_button">
@@ -242,57 +219,6 @@
           class="{{connectStatus.status}} btn {{style}}">
     <span class="bb-statuslight"></span>
   </button>
-</template>
-
-<template name="header_lastupdates">
-<!-- Last update bar -->
-  <div class="bb-lastupdate">
-    <span class="right pull-right">
-    <a href="/oplogs" class="oplogs-link"
-       title="Complete blackboard update log">more...</a>
-    </span>
-    <span class="left pull-left label label-inverse">
-    Last update:
-    </span>
-    <span class="center">
-    {{#with lastupdates}}
-    <span class="timestamp">{{pretty_ts timestamp}}</span>
-    {{message}}
-    <span class="comma-list">{{#each objects}}{{link id}}{{/each}}</span>
-    {{#if nick}} (<strong title="{{nickOrName nick}}">{{nick}}</strong>){{/if}}
-    {{/with}}
-    </span>
-  </div>
-</template>
-
-<template name="header_lastchats">
-<!-- Last chat bar -->
-  <div class="bb-lastchat">
-    <div class="right pull-right">
-      <a href="/chat/general/0" class="chat-link"
-         title="Complete {{roomname}} chat">more...</a><br/>
-      <a href="/chat/general/0" class="chat-link bb-pop-out"
-         title="Pop out {{roomname}} chat"
-         target="chat0">pop out <i class="fas fa-external-link-alt"></i></a>
-    </div>
-    <span class="left pull-left label label-inverse">
-      {{roomname}}:
-    </span>
-    <span class="center">
-    {{#each lastchats}}
-    <p class="messageRow">
-    <span class="timestamp">{{pretty_ts timestamp}}</span>
-    {{#if action}}
-      <strong title="{{nickOrName nick}}">{{nick}}</strong> {{msgbody}}
-    {{else}}
-      <strong title="{{nickOrName nick}}">{{nick}}:</strong>
-      {{#if to}}/msg <span title="{{nickOrName to}}">{{to}}</span>{{/if}}
-      {{msgbody}}
-    {{/if}}
-    </p>
-    {{/each}}
-    </span>
-  </div>
 </template>
 
 <template name="header_nickmodal_contents">

--- a/header.html
+++ b/header.html
@@ -139,11 +139,7 @@
     {{> Template.dynamic template=crumb_template}}
   {{/each}}
   <li class="fill">
-    {{#if generalChat}}
-      {{> header_lastchats "oplog/0"}}
-    {{else}}
-      {{>header_lastchats_switcher}}
-    {{/if}}
+    {{> header_lastchats}}
   {{#if currentPageEquals "chat"}}
     {{> chat_header }}
   {{/if}}
@@ -229,7 +225,7 @@
 
 <template name="header_lastchats">
 <!-- Last chat bar -->
-  <div class="bb-lastchat" id="bb-lastchat-{{canonical this}}">
+  <div class="bb-lastchat">
     <div class="rooms fas fa-{{roomicon}}" title={{roomname}}>
     </div>
     <div class="chats">
@@ -237,7 +233,7 @@
     <p class="messageRow">
     <span class="timestamp">{{pretty_ts timestamp}}</span>
     {{#if oplog}}
-      {{msgbody}} {{link id}} {{#if nick}} (<strong title="{{nickOrName nick}}">{{nick}}</strong>){{/if}}
+      {{#with icon_label}}<span class="badge{{#with this.[1]}} badge-{{this}}{{/with}}"><i class="fas fa-{{this.[0]}}"></i></span>{{/with}}{{msgbody}} {{link id}} {{#if nick}} (<strong title="{{nickOrName nick}}">{{nick}}</strong>){{/if}}
     {{else if action}}
       <strong title="{{nickOrName nick}}">{{nick}}</strong> {{msgbody}}
     {{else}}
@@ -248,13 +244,6 @@
     </p>
     {{/each}}
     </div>
-  </div>
-</template>
-
-<template name="header_lastchats_switcher">
-  <div class="bb-lastchat-switcher {{#if oplog}}oplog{{/if}}">
-    {{> header_lastchats "general/0"}}
-    {{> header_lastchats "oplog/0"}}
   </div>
 </template>
 

--- a/header.less
+++ b/header.less
@@ -137,6 +137,17 @@
     }
   }
 }
+.bb-lastchat-switcher {
+  position: relative;
+  transition-property: top;
+  transition-duration: 200ms;
+  transition-timing-function: ease-in-out;
+  top:0px;
+  &.oplog {
+    top:-36px;
+  }
+
+}
 .bb-statuslight {
   line-height: 1;
   display: inline-block;

--- a/header.less
+++ b/header.less
@@ -111,7 +111,12 @@
         overflow: hidden;
         position: relative;
         & > .bb-lastchat {
+          /* This makes it take up exactly all the space in the li,
+             but it doesn't count toward the li's size so the li
+             can shrink to 0 if necessary. */
           position: absolute;
+          left: 0;
+          right:0;
         }
       }
       .bb-drive-buttons {

--- a/header.less
+++ b/header.less
@@ -137,17 +137,6 @@
     }
   }
 }
-.bb-lastchat-switcher {
-  position: relative;
-  transition-property: top;
-  transition-duration: 200ms;
-  transition-timing-function: ease-in-out;
-  top:0px;
-  &.oplog {
-    top:-36px;
-  }
-
-}
 .bb-statuslight {
   line-height: 1;
   display: inline-block;

--- a/header.less
+++ b/header.less
@@ -109,6 +109,10 @@
         flex-grow: 1;
         flex-shrink: 1;
         overflow: hidden;
+        position: relative;
+        & > .bb-lastchat {
+          position: absolute;
+        }
       }
       .bb-drive-buttons {
         .bb-drive-link + .tooltip .tooltip-arrow {

--- a/header.less
+++ b/header.less
@@ -55,6 +55,15 @@
       margin: 0px;
       border-bottom: 1px solid black;
       box-shadow: 0px 2px 4px rgba(0,0,0,0.5);
+      #bb-avatar-dropdown {
+        a {
+          padding-top: 8px;
+          padding-bottom: 8px
+        }
+        .caret {
+          margin-top: 10px;
+        }
+      }
       & > li {
         display: flex;
         flex-grow: 0;

--- a/header.less
+++ b/header.less
@@ -55,7 +55,7 @@
       margin: 0px;
       border-bottom: 1px solid black;
       box-shadow: 0px 2px 4px rgba(0,0,0,0.5);
-      li {
+      & > li {
         display: flex;
         flex-grow: 0;
         flex-shrink: 0;
@@ -78,6 +78,7 @@
         a:not(.current) i:not(.current):hover {
           border-bottom: 1px solid white;
         }
+        .btn-group .caret { border-top-color:white; border-bottom-color: white;}
         &.dropdown.open > ul.dropdown-menu {
           display: flex;
           background: url('/img/irongrip.png');
@@ -87,10 +88,11 @@
             display: flex;
             flex-flow: row nowrap;
             color: #c4c4c4;
-            a {
+            a[href] {
               color: #c4c4c4;
-              &:hover { background: none; }
+              &:hover { background: none; color: white;}
             }
+            a + a { padding-left: 0px; margin-left: -10px; }
           }
         }
       }

--- a/header.less
+++ b/header.less
@@ -152,7 +152,7 @@
   .waiting & { --glyph: "\f110"; animation: fa-spin 2s infinite steps(8); color: #F80; }
 }
 #bb-body {
-  .timestamp { font-size: .65em; }
+  .timestamp { font-size: 10px; }
 }
 
 @media(max-width:480px) {

--- a/options_dropdown.html
+++ b/options_dropdown.html
@@ -1,8 +1,8 @@
 <template name="options_dropdown">
   <div class="btn-group text-left bb-display-settings">
-    <button class="btn btn-small btn-info dropdown-toggle" data-toggle="dropdown" title="Display Settings">
+    <button class="btn btn-small btn-info dropdown-toggle" data-toggle="dropdown" title="Settings">
       <i class="fas fa-sliders-h"></i>
-      <span class="bb-display-settings-title">Display Settings</span>
+      <span class="bb-display-settings-title">Settings</span>
       <span class="caret"></span>
     </button>
     <ul class="dropdown-menu pull-left bb-display-settings-list nav-list">
@@ -51,6 +51,12 @@
           Prioritize Stuck
         </label>
       </a></li>
+      <li><a name="bb-nosfx">
+        <label class="checkbox bb-sfx-mute" title="Silence sound effects. Doesn't affect Jitsi meetings.">
+          <input type="checkbox" name="bb-sfx-mute" checked="{{sfxMute}}">
+          Mute Sound Effects
+        </label>
+      </a></li>
       <li class="nav-header">Chat</li>
       <li><a name="bb-nobot">
         <label class="checkbox bb-bot-mute" title="Silence fun bot responses like memes, but not useful ones like announcements and command replies">
@@ -75,7 +81,7 @@
         <li><a name="bb-start-video-muted">
           <label class="checkbox bb-start-video-muted" title="Join Jitsi meetings with video muted">
             <input type="checkbox" name="bb-start-video-muted" checked="{{startVideoMuted}}">
-            Start Video Muted
+            Start Video Disabled
           </label>
         </a></li>
       {{/if}}

--- a/page.html
+++ b/page.html
@@ -24,7 +24,7 @@ function onGoogleApiLoad() {
     {{#if currentPageEquals "graph"}}
       {{>graph}}
     {{else}}
-      <div id="bb-body" class="{{#if boringMode}}boring{{/if}} {{#if compactHeader}}compactHeader{{/if}}">
+      <div id="bb-body" class="{{#if boringMode}}boring{{/if}}">
         {{> page }}
       </div>
       {{> header_confirmmodal}}

--- a/puzzle.html
+++ b/puzzle.html
@@ -1,14 +1,14 @@
 <template name="puzzle_info">
 <div class="bb-puzzle-frame">
 <div class="{{#if stuck}}bb-status-stuck{{else if puzzle.solved}}bb-status-solved{{/if}}">
-  <h1>{{puzzle.name}}</h1>
   <h2>
+    {{> header_breadcrumbs_unsolved_buttons puzzle}}
+    {{#if puzzle.drive}}<a class="bb-drive-link" title="Open Drive folder in new window" target="_blank" href="{{drive_link puzzle.drive}}"><i class="fab fa-google-drive"></i></a>{{/if}}
     {{>favorite puzzle}}
     {{#if puzzle.link}}<a href="{{puzzle.link}}" target="_blank" title="Open puzzle in new window"><i class="fas fa-link"></i></a>{{/if}}
-    {{#if puzzle.drive}}<a class="bb-drive-link" title="Open Drive folder in new window" target="_blank" href="{{drive_link puzzle.drive}}"><i class="fab fa-google-drive"></i></a>{{/if}}
-    {{> header_breadcrumbs_unsolved_buttons puzzle}}
-    
   </h2>
+  
+  <h1>{{puzzle.name}}</h1>
 </div>
 <table class="bb-puzzle-info-tags"><tbody>
 {{#with puzzle}}

--- a/puzzle.html
+++ b/puzzle.html
@@ -1,9 +1,14 @@
 <template name="puzzle_info">
 <div class="bb-puzzle-frame">
 <div class="{{#if stuck}}bb-status-stuck{{else if puzzle.solved}}bb-status-solved{{/if}}">
-  <h1>{{puzzle.name}} {{>favorite puzzle}}
-    {{#if puzzle.link}}<nobr>(<a href="{{puzzle.link}}" target="_blank">link<i class="fas fa-external-link-alt"></i></a>)</nobr>{{/if}}
-  </h1>
+  <h1>{{puzzle.name}}</h1>
+  <h2>
+    {{>favorite puzzle}}
+    {{#if puzzle.link}}<a href="{{puzzle.link}}" target="_blank" title="Open puzzle in new window"><i class="fas fa-link"></i></a>{{/if}}
+    {{#if puzzle.drive}}<a class="bb-drive-link" title="Open Drive folder in new window" target="_blank" href="{{drive_link puzzle.drive}}"><i class="fab fa-google-drive"></i></a>{{/if}}
+    {{> header_breadcrumbs_unsolved_buttons puzzle}}
+    
+  </h2>
 </div>
 <table class="bb-puzzle-info-tags"><tbody>
 {{#with puzzle}}
@@ -153,7 +158,7 @@
 </template>
 
 <template name="puzzle_summon_button">
-<button class="btn {{#if currentPageEquals "chat"}}btn-small{{/if}} bb-summon-btn {{#if stuck}}stuck{{else}}unstuck{{/if}} btn-inverse">
+<button class="btn btn-small bb-summon-btn {{#if stuck}}stuck{{else}}unstuck{{/if}} btn-inverse">
 {{#unless currentPageEquals "chat"}}<i class="fas fa-{{#if stuck}}lightbulb{{else}}ambulance{{/if}}"></i>{{/unless}}
 {{#if stuck}}Clear STUCK status{{else}}Flag as STUCK{{/if}}
 </button>
@@ -222,9 +227,9 @@
 </template>
 
 <template name="puzzle_callin_button">
-<button class="btn {{#if currentPageEquals "chat"}}btn-small{{/if}} bb-callin-btn btn-inverse">
-{{! TODO: after bootstrap upgrade, change icon to earphone }}
-{{#unless currentPageEquals "chat"}}<i class="fas fa-phone"></i>{{/unless}}
+<button class="btn btn-small bb-callin-btn btn-inverse"
+  title="Request call-in">
+<i class="fas fa-phone"></i>
 Request Call-In
 </button>
 </template>

--- a/splitter.less
+++ b/splitter.less
@@ -65,18 +65,18 @@ html.fullHeight {
           display: none;
         }
         position: absolute;
-        right: var(--right-column);
+        right: ~"calc(var(--right-column) + 16px)";
         margin-right: 6px;
         background: var(--bg-color);
         border: 1px solid #888;
         padding-left: 2px; padding-right: 4px;
-        padding-top: 5px;
+        padding-top: 0px;
       }
       .bb-left-header {
         position: absolute; right: 100%; writing-mode: vertical-lr; top:10px;
       }
       iframe {
-        padding-top: 5px; /* was 26px, but we're chosing to overlap header */
+        padding-top: 0px;
         margin-bottom: -5px;
         border-top: none;
       }


### PR DESCRIPTION
Makes the header one line. Moves sound effects mute to the settings menu. Adds a single combined oplog/main chat widget to the end of the breadcrumbs, except on pages that already have main chat where it's oplogs only.
Fixes #223 