### PR TITLE
Add button that clears Jitsi's local storage

### DIFF
--- a/blackboard.html
+++ b/blackboard.html
@@ -22,6 +22,11 @@
     <li><a href="#unassigned{{_id}}"><i class="fas fa-chevron-right"></i>Unassigned</a></li>
     {{/if}}
     {{/each}}
+    <li class="fill"></li>
+    {{#if hasJitsiLocalStorage}}
+      <li class="nav-header">Troubleshooting</li>
+      <li><a href="#" class="bb-clear-jitsi-storage" title="Jitsi can sometimes store so much data in local storage that when it tries to pass it to the iframe, it exceeds the browser's URL size limit. Click here to clear that storage.">Clear Jitsi Local Storage</a></li>
+    {{/if}}
   </ul>
 </div>
 <!-- puzzles w/ index -->

--- a/blackboard.less
+++ b/blackboard.less
@@ -116,9 +116,16 @@ body.has-emojis {
   }
   ul {
     margin-left: 5px;
+    display: flex;
+    flex-flow: column nowrap;
+    min-height: 100%;
     li {
       display: block;
-      a {
+      flex-grow: 0;
+      &.fill {
+        flex-grow: 1;
+      }
+      a, .btn-link {
         display: block;
         &.bb-wiki { text-align: center; }
       }

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -212,6 +212,8 @@ Template.blackboard.helpers
     model.Puzzles.find query
   stuckPuzzles: -> model.Puzzles.find
     'tags.status.value': /^stuck/i
+  hasJitsiLocalStorage: ->
+    reactiveLocalStorage.getItem 'jitsiLocalStorage'
 
 Template.blackboard_status_grid.helpers
   rounds: round_helper
@@ -246,6 +248,8 @@ Template.blackboard.onDestroyed ->
 Template.blackboard.events
   "click .bb-menu-button .btn": (event, template) ->
     template.$('.bb-menu-drawer').modal 'show'
+  'click .bb-menu-drawer a.bb-clear-jitsi-storage': (event, template) ->
+    reactiveLocalStorage.removeItem 'jitsiLocalStorage'
   'click .bb-menu-drawer a': (event, template) ->
     template.$('.bb-menu-drawer').modal 'hide'
     href = event.target.getAttribute 'href'


### PR DESCRIPTION
This helps if the stored value is so large that it exceeds the browser's URL limit for the meeting iframe.
Fixes #227 