### PR TITLE
Make read line orange

### DIFF
--- a/chat.less
+++ b/chat.less
@@ -205,11 +205,11 @@
     }
   }
   .bb-message-last-read {
-    color: #33f;
-    border-bottom: 2px solid #66f;
+    color: #960;
+    border-bottom: 2px solid #960;
     .darkMode & {
-      color: #ddf;
-      border-bottom: 2px solid #99f;
+      color: #fd9;
+      border-bottom: 2px solid #fd9;
     }
     font-size: 8px;
     line-height: 8px;


### PR DESCRIPTION
Since chats that mention you and private messages are blue, make the read line orange to have better contrast.
Fixes #231 