### PR TITLE
Add header_ignore field to messages

### DIFF
--- a/client/header.coffee
+++ b/client/header.coffee
@@ -525,7 +525,7 @@ Template.header_lastchats.helpers
     else
       $in: ['oplog/0', 'general/0']
     model.Messages.find {
-      room_name: query, system: {$ne: true}, bodyIsHtml: {$ne: true}, nick: {$ne: botuser()}
+      room_name: query, system: {$ne: true}, bodyIsHtml: {$ne: true}, header_ignore: {$ne: true}
     }, {sort: [["timestamp","desc"]], limit: RECENT_GENERAL_LIMIT}
   msgbody: ->
     if this.bodyIsHtml then new Spacebars.SafeString(this.body) else this.body

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -183,6 +183,7 @@ if Meteor.isServer
 #   oplog:  boolean (true for semi-automatic operation log message)
 #   presence: optional string ('join'/'part' for presence-change only)
 #   bot_ignore: optional boolean (true for messages from e.g. email or twitter)
+#   header_ignore: optional boolean (don't show in header)
 #   to:   destination of pm (optional)
 #   poll: _id of poll (optional)
 #   starred: boolean. Pins this message to the top of the puzzle page or blackboard.
@@ -683,7 +684,9 @@ doc_id_to_link = (id) ->
         provided: !!args.provided
         status: 'pending'
       , {suppressLog:true}
-      msg = action: true
+      msg =
+        action: true
+        header_ignore: true
       # send to the general chat
       msg.body = body(specifyPuzzle: true)
       unless args?.suppressRoom is "general/0"
@@ -789,7 +792,7 @@ doc_id_to_link = (id) ->
       # one message to the general chat
       delete msg.room_name
       msg.body += " (#{puzzle.name})" if puzzle?.name?
-      Meteor.call 'newMessage', msg
+      Meteor.call 'newMessage', {msg..., header_ignore: true}
 
       if callin.callin_type is callin_types.ANSWER
         # one message to the each metapuzzle's chat
@@ -847,7 +850,7 @@ doc_id_to_link = (id) ->
       # one message to the general chat
       delete msg.room_name
       msg.body += " (#{puzzle.name})" if puzzle.name?
-      Meteor.call 'newMessage', msg
+      Meteor.call 'newMessage', {msg..., header_ignore: true}
       puzzle.feedsInto.forEach (meta) ->
         msg.room_name = "puzzles/#{meta}"
         Meteor.call 'newMessage', msg
@@ -914,6 +917,7 @@ doc_id_to_link = (id) ->
         room_name: Match.Optional NonEmptyString
         useful: Match.Optional Boolean
         bot_ignore: Match.Optional Boolean
+        header_ignore: Match.Optional Boolean
         suppressLastRead: Match.Optional Boolean
       return if this.isSimulation # suppress flicker
       suppress = args.suppressLastRead
@@ -1133,6 +1137,7 @@ doc_id_to_link = (id) ->
         action: true
         bodyIsHtml: true
         body: body
+        header_ignore: true
       return
 
     unsummon: (args) ->
@@ -1163,6 +1168,7 @@ doc_id_to_link = (id) ->
       Meteor.call 'newMessage',
         action: true
         body: body
+        header_ignore: true
       return
 
     getRoundForPuzzle: (puzzle) ->

--- a/server/imports/hubot.coffee
+++ b/server/imports/hubot.coffee
@@ -157,6 +157,7 @@ class BlackboardAdapter extends Hubot.Adapter
       room_name: 'general/0'
       action: true
       bot_ignore: true
+      header_ignore: true
     @emit 'connected'
 
   # Public: Raw method for shutting the bot down.

--- a/server/imports/newMessage.coffee
+++ b/server/imports/newMessage.coffee
@@ -32,6 +32,9 @@ export newMessage = (newMsg) ->
     room_name: NonEmptyString
     useful: Match.Optional Boolean
     bot_ignore: Match.Optional Boolean
+    # True for messages generated in main chat room as part of events that also generate oplogs.
+    # Since oplogs are always in the header, these are redundant there, but should be in the chat room itself.
+    header_ignore: Match.Optional Boolean
     # Present only in messages received via IMAP.
     # Nick will be sender's address.
     mail: Match.Optional

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -154,6 +154,7 @@ Meteor.publish 'recent-header-messages', loginRequired ->
     system: $ne: true
     bodyIsHtml: $ne: true
     deleted: $ne: true
+    header_ignore: $ne: true
     $or: [ {to: null}, {to: @userId}, {nick: @userId }]
   ,
     sort: [['timestamp', 'desc']]


### PR DESCRIPTION
Causes them to be excluded from the recent chat bar in the header. Primarily used for messages that are sent at the same time as an oplog, since they would be redundant in the header.