### PR TITLE
Remove compatibility shims

### DIFF
--- a/server/batch.coffee
+++ b/server/batch.coffee
@@ -12,23 +12,6 @@ model = share.model
 # Was in lib/model.coffee, but that meant it was loaded on the client even
 # though it could never run there.
 
-model.CallIns.update
-  status: null
-,
-  $set: status: 'pending'
-,
-  multi: true
-try
-  Promise.await model.CallIns.rawCollection().dropIndex('target_1_answer_1')
-# No problem if it doesn't exist.
-
-Meteor.users.find(gravatar: $exists: true).forEach (doc) ->
-  Meteor.users.update doc._id,
-    $set:
-      gravatar_md5: md5 doc.gravatar
-    $unset:
-      gravatar: true
-
 # helper function: like _.throttle, but always ensures `wait` of idle time
 # between invocations.  This ensures that we stay chill even if a single
 # execution of the function starts to exceed `wait`.


### PR DESCRIPTION
Any callin created with the 2021 version has a status, so we don't need to set it. Similarly, it doesn't have the target + answer index so we don't need to drop it.
Users won't have their gravatar set with a stored email address, so we don't need to convert it to an md5.