### PR TITLE
Make links a template instead of a helper

### DIFF
--- a/blackboard.html
+++ b/blackboard.html
@@ -180,7 +180,7 @@
               title="Edit the name of this round"></i>
           {{else}}
             <span class="collapse-toggle"></span>
-            {{link id=_id title="Chat room for round" chat=true icon="fas fa-comments" class="pull-right bb-round-chat"}}
+            {{>link id=_id title="Chat room for round" chat=true icon="fas fa-comments" class="pull-right bb-round-chat"}}
             {{#if link}}<a class="pull-right" href="{{link}}" title="Link to hunt site"><i class="fas fa-link"></i></a>{{/if}}
           {{/if}}
         {{name}}
@@ -245,14 +245,14 @@
   <table>
   <tbody>
     {{#each rounds}}
-    <tr><th colspan=2 class="bb-status-grid-round bb-status-{{#if solved}}solved{{else if stuck this}}stuck{{else}}unsolved{{/if}}">{{link id=_id}}</th></tr>
+    <tr><th colspan=2 class="bb-status-grid-round bb-status-{{#if solved}}solved{{else if stuck this}}stuck{{else}}unsolved{{/if}}">{{>link id=_id}}</th></tr>
       {{#each metas}}
       <tr>
         <td class="bb-status-grid-meta bb-status-{{#if puzzle.solved}}solved{{else if stuck puzzle}}stuck{{else}}unsolved{{/if}}">
-            {{link id=puzzle._id title="meta" text=puzzle.name}}
+            {{>link id=puzzle._id}}
         </td><td class="bb-status-grid-puzzles">
         {{#each puzzles puzzle.puzzles}}<div class="bb-status-grid-cell bb-status-{{#if puzzle.solved}}solved{{else if stuck puzzle}}stuck{{else}}unsolved{{/if}}">
-            {{link id=puzzle._id title=puzzle.name text=puzzle_num}}
+            {{>link id=puzzle._id title=puzzle.name text=puzzle_num}}
         </div>{{/each}}</td>
       </tr>
       {{/each}}
@@ -262,7 +262,7 @@
           <td class="bb-status-grid-meta bb-status-unsolved">Unassigned</td>
           <td class="bb-status-grid-puzzles">
           {{#each puzzles this}}<div class="bb-status-grid-cell bb-status-{{#if puzzle.solved}}solved{{else if stuck puzzle}}stuck{{else}}unsolved{{/if}}">
-            {{link id=puzzle._id title=puzzle.name text=puzzle_num}}
+            {{>link id=puzzle._id title=puzzle.name text=puzzle_num}}
           </div>{{/each}}</td>
         </tr>
         {{/if}}
@@ -274,7 +274,7 @@
 
 <template name="blackboard_othermeta_link">
   <span class="bb-othermeta">{{#with color}}<span class="bb-colorbox" style="background-color: {{this}}"></span>{{/with}}
-  {{link _id}}</span>
+  {{>link id=_id}}</span>
 </template>
 
 <template name="blackboard_puzzle_cells">
@@ -294,12 +294,12 @@
         <span class="collapse-toggle"></span>
         {{#if puzzle.spreadsheet}}<a href="{{spread_link puzzle.spreadsheet}}" target="_blank" title="Spreadsheet for puzzle" class="pull-right"><i class="fas fa-th"></i></a>{{/if}}
         {{#if puzzle.doc}}<a href="{{doc_link puzzle.doc}}" target="_blank" title="Doc for puzzle" class="pull-right"><i class="fas fa-file"></i></a>{{/if}}
-        {{link id=puzzle._id title="Chat room for puzzle" chat=true class="pull-right" icon="fas fa-comments"}}
+        {{>link id=puzzle._id title="Chat room for puzzle" chat=true class="pull-right" icon="fas fa-comments"}}
         {{#if puzzle.link}}<a class="pull-right" href="{{puzzle.link}}" title="Link to hunt site"><i class="fas fa-puzzle-piece"></i></a>{{/if}}
         {{#with jitsiLink}}<a class="pull-right" href="{{this}}" title="Link to video call" target="jitsi"><i class="fas fa-video"></i></a>{{/with}}
         {{>favorite puzzle}}
       {{/if}}
-      {{link id=puzzle._id editing=canEdit}}
+      {{>link id=puzzle._id editing=canEdit}}
     {{/if}}
     </div>
     {{#if canEdit}}

--- a/callins.html
+++ b/callins.html
@@ -51,7 +51,7 @@
 
 <template name="callin_row">
   <tr data-bbedit="{{_id}}">
-    <td>{{link id=target title="Chat room" chat=true icon="fas fa-comments" class="pull-right"}}{{link target}}{{#if hunt_link}}
+    <td>{{>link id=target title="Chat room" chat=true icon="fas fa-comments" class="pull-right"}}{{>link target}}{{#if hunt_link}}
     <br/><small>&nbsp;↦&nbsp;<a href="{{hunt_link}}"
             target="_blank">on&nbsp;hunt&nbsp;site
     </a></small>
@@ -130,7 +130,7 @@
         {{#if currentPageEquals "callins"}}
         <button class="btn btn-success bb-quip-next">Use</button>
         {{/if}}
-        {{link id=_id text="Edit" class="btn" title=name}}
+        {{>link id=_id text="Edit" class="btn" title=name}}
         <button class="btn bb-quip-punt">Punt</button>
         <!--<button class="btn bb-quip-remove">Remove</button>-->
       </div>

--- a/client/header.coffee
+++ b/client/header.coffee
@@ -20,28 +20,6 @@ keyword_or_positional = share.keyword_or_positional = (name, args) ->
   a[name] = args
   return a
 
-# link various types of objects
-Template.registerHelper 'link', (args) ->
-  args = keyword_or_positional 'id', args
-  return "" unless args.id
-  n = model.Names.findOne(args.id)
-  return args.id.slice(0,8) unless n
-  return ('' + (args.text ? n.name)) if args.editing
-  extraclasses = if args.class then (' '+args.class) else ''
-  title = ''
-  if args.title?
-    title = ' title="' + \
-      args.title.replace(/[&\"]/g, (c) -> '&#' + c.charCodeAt(0) + ';') + '"'
-  prefix = if args.chat then '/chat' else ''
-  type = if args.chat then 'chat' else n.type
-  link = "<a href='#{prefix}/#{n.type}/#{n._id}' class='#{type}-link#{extraclasses}' #{title}>"
-  if args.icon
-    link += "<i class='#{args.icon}'></i>"
-  else
-    link += UI._escape('' + (args.text ? n.name))
-  link += '</a>'
-  return new Spacebars.SafeString(link)
-
 do ->
   clickHandler = (event, template) ->
     return unless event.button is 0 # check right-click

--- a/client/link.coffee
+++ b/client/link.coffee
@@ -3,6 +3,7 @@
 model = share.model # import
 
 Template.link.onCreated ->
+  console.log Template.currentData()
   @autorun =>
     @target = model.Names.findOne(Template.currentData().id)
 

--- a/client/link.coffee
+++ b/client/link.coffee
@@ -3,7 +3,6 @@
 model = share.model # import
 
 Template.link.onCreated ->
-  console.log Template.currentData()
   @autorun =>
     @target = model.Names.findOne(Template.currentData().id)
 

--- a/client/link.coffee
+++ b/client/link.coffee
@@ -1,0 +1,11 @@
+'use strict'
+
+model = share.model # import
+
+Template.link.onCreated ->
+  @autorun =>
+    @target = model.Names.findOne(Template.currentData().id)
+
+Template.link.helpers
+  target: -> Template.instance().target
+  text: -> Template.instance().data.text ? Template.instance().target?.name

--- a/header.html
+++ b/header.html
@@ -233,12 +233,12 @@
     <p class="messageRow">
     <span class="timestamp">{{pretty_ts timestamp}}</span>
     {{#if oplog}}
-      {{#with icon_label}}<span class="badge{{#with this.[1]}} badge-{{this}}{{/with}}"><i class="fas fa-{{this.[0]}}"></i></span>{{/with}}{{msgbody}} {{link id}} {{#if nick}} (<strong title="{{nickOrName nick}}">{{nick}}</strong>){{/if}}
+      {{#with icon_label}}<span class="badge{{#with this.[1]}} badge-{{this}}{{/with}}"><i class="fas fa-{{this.[0]}}"></i></span>{{/with}}{{msgbody}} {{>link id=id}} {{#if nick}} (<strong title="{{nickOrName nick}}">{{nick}}</strong>){{/if}}
     {{else if action}}
       <strong title="{{nickOrName nick}}">{{nick}}</strong> {{msgbody}}
     {{else}}
       {{#if equal room_name "callins/0"}}(<a class="callins-link" href="/callins">Callin Queue</a>)
-      {{else unless equal room_name "general/0"}}({{link puzzle_id}}){{/if}}
+      {{else unless equal room_name "general/0"}}({{>link id=puzzle_id}}){{/if}}
       {{#if equal to currentUser._id}}
         <i title="Private Message" class="fas fa-people-arrows"></i>
       {{/if}}

--- a/link.html
+++ b/link.html
@@ -1,7 +1,7 @@
 <template name="link">
   {{#unless target}}
     {{id}}
-  {{else if editing}}
+  {{else if this.editing}}
     {{text}}
   {{else}}
     <a href="{{#if chat}}/chat{{/if}}/{{target.type}}/{{id}}" class="{{#if chat}}chat{{else}}{{target.type}}{{/if}}-link {{class}}" title="{{title}}">

--- a/link.html
+++ b/link.html
@@ -1,0 +1,15 @@
+<template name="link">
+  {{#unless target}}
+    {{id}}
+  {{else if editing}}
+    {{text}}
+  {{else}}
+    <a href="{{#if chat}}/chat{{/if}}/{{target.type}}/{{id}}" class="{{#if chat}}chat{{else}}{{target.type}}{{/if}}-link {{class}}" title="{{title}}">
+      {{#if icon}}
+        <i class="{{icon}}" title="{{#unless title}}{{text}}{{/unless}}"></i>
+      {{else}}
+        {{text}}
+      {{/if}}
+    </a>
+  {{/unless}}
+</template>

--- a/oplog.html
+++ b/oplog.html
@@ -14,7 +14,7 @@
   <div class="bb-oplog">
     <span class="timestamp">{{pretty_ts this.timestamp}}</span>
     {{body}} {{prettyType}}
-    {{link id}}
+    {{>link id=id}}
     {{#if nick}} (<strong title="{{nickOrName nick}}">{{nick}}</strong>){{/if}}
   </div>
   {{/unless}}

--- a/puzzle.html
+++ b/puzzle.html
@@ -90,7 +90,7 @@
   <tr><th>Puzzle in round</th><th>Answer</th>{{#each cares}}<th>{{name}}</th>{{/each}}</tr>
   {{#each puzzle.puzzles}}{{#with getPuzzle}}
     <tr>
-      <td>{{link _id}}</td>
+      <td>{{>link id=_id}}</td>
       <td class="answer">{{#if solved}}{{tag "answer"}}{{/if}}</td>
       {{#each t in cares}}
         <td>{{tag t.name}}</td>


### PR DESCRIPTION
This saves a bunch of HTML parsing since Blaze would otherwise have to parse the HTML of the link into DOM objects instead of generating it as DOM objects to begin with.
Fixes #358 