### PR TITLE
Track last chat message against last read in favorite puzzle

### DIFF
--- a/blackboard.html
+++ b/blackboard.html
@@ -148,7 +148,7 @@
               <tbody>
                 <tr><th colspan="{{nCols}}" id="favorites"><h2>Favorite Puzzles</h2></th></tr>
                 {{#each faves}}
-                  {{>blackboard_puzzle _id=_id puzzle=this}}
+                  {{>blackboard_favorite_puzzle}}
                 {{/each}}
               </tbody>
             {{/if}}
@@ -160,6 +160,11 @@
       {{/if}}
     </table>
   </div><!-- bb-tables -->
+</template>
+
+<!-- this exists to add a subscription. -->
+<template name="blackboard_favorite_puzzle">
+  {{>blackboard_puzzle _id=_id puzzle=this}}
 </template>
 
 <template name="blackboard_round">
@@ -475,6 +480,11 @@
           {{#with solverMinutes}}<br><i class="fas fa-user-clock"></i> {{this}} solver-minutes{{/with}}
         {{else if stuck puzzle}}stuck since {{pretty_ts timestamp=puzzle.tags.status.touched style="brief duration"}}
         {{else}}added {{pretty_ts timestamp=puzzle.created style="brief duration"}}
+        {{/if}}
+        {{#if puzzle.last_message_timestamp}}
+          <div class="bb-recent-puzzle-chat {{#if new_message}}updated{{/if}}">
+            last chat {{pretty_ts timestamp=puzzle.last_message_timestamp style="brief duration"}}
+          </div>
         {{/if}}
       </td>
     {{/unless}}

--- a/blackboard.less
+++ b/blackboard.less
@@ -612,6 +612,21 @@ input[type=color] {
       font-size: 85%;
     }
   }
+  .bb-recent-puzzle-chat {
+    &::before {
+      font-family: "Font Awesome 5 Free";
+      font-weight: 400;
+      content: "\f075";
+      margin-right: 0.5em;
+    }
+    &.updated {
+      font-weight: bold;
+      &::before {
+        font-weight: 900;
+        content: "\f7f5"
+      }
+    }
+  }
 }
 
 .bb-hide-status {

--- a/client/blackboard.app-test.coffee
+++ b/client/blackboard.app-test.coffee
@@ -26,6 +26,18 @@ describe 'blackboard', ->
     civId = share.model.Rounds.findOne name: 'Civilization'
     chai.assert.isNotNull $("##{civId._id}").html()
 
+  it 'makes a puzzle a favorite', ->
+    share.Router.BlackboardPage()
+    await waitForSubscriptions()
+    chai.assert.isUndefined $('#favorites').html()
+    # there should be a table header for the Civilization round.
+    granary = share.model.Puzzles.findOne name: 'Granary Of Ur'
+    bank = share.model.Puzzles.findOne name: 'Letter Bank'
+    $("#m#{granary._id} tr[data-puzzle-id='#{bank._id}'] .bb-favorite-button").click()
+    await waitForSubscriptions()
+    await afterFlushPromise()
+    chai.assert.isNotNull $('#favorites').html()
+
 describe 'login', ->
   @timeout 10000
   it 'only sends email hash', ->

--- a/client/blackboard.app-test.coffee
+++ b/client/blackboard.app-test.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-import {waitForSubscriptions, afterFlushPromise, login, logout} from './imports/app_test_helpers.coffee'
+import {waitForMethods, waitForSubscriptions, afterFlushPromise, login, logout} from './imports/app_test_helpers.coffee'
 import chai from 'chai'
 
 describe 'blackboard', ->
@@ -16,7 +16,7 @@ describe 'blackboard', ->
     await waitForSubscriptions()
     # there should be a table header for the Civilization round.
     civId = share.model.Rounds.findOne name: 'Civilization'
-    chai.assert.isNotNull $("##{civId._id}").html()
+    chai.assert.isDefined $("#round#{civId._id}").html()
 
   it 'renders in edit mode', ->
     share.Router.EditPage()
@@ -24,19 +24,23 @@ describe 'blackboard', ->
     await afterFlushPromise()
     # there should be a table header for the Civilization round.
     civId = share.model.Rounds.findOne name: 'Civilization'
-    chai.assert.isNotNull $("##{civId._id}").html()
+    chai.assert.isDefined $("#round#{civId._id}").html()
 
   it 'makes a puzzle a favorite', ->
     share.Router.BlackboardPage()
     await waitForSubscriptions()
+    await afterFlushPromise()
     chai.assert.isUndefined $('#favorites').html()
     # there should be a table header for the Civilization round.
     granary = share.model.Puzzles.findOne name: 'Granary Of Ur'
     bank = share.model.Puzzles.findOne name: 'Letter Bank'
-    $("#m#{granary._id} tr[data-puzzle-id='#{bank._id}'] .bb-favorite-button").click()
+    chai.assert.isDefined $("#m#{granary._id} tr[data-puzzle-id=\"#{bank._id}\"] .bb-favorite-button").html()
+    $("#m#{granary._id} tr[data-puzzle-id=\"#{bank._id}\"] .bb-favorite-button").click()
+    await waitForMethods()
     await waitForSubscriptions()
     await afterFlushPromise()
-    chai.assert.isNotNull $('#favorites').html()
+    chai.assert.isDefined $('#favorites').html()
+    chai.assert.isDefined $("tr[data-puzzle-id=\"#{bank._id}\"] .bb-recent-puzzle-chat").html()
 
 describe 'login', ->
   @timeout 10000

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -357,6 +357,10 @@ Template.blackboard.events okCancelEvents('.bb-editable input[type=text]',
     Session.set 'editing', undefined # not editing anything anymore
 )
 
+Template.blackboard_favorite_puzzle.onCreated ->
+  @autorun =>
+    @subscribe 'last-puzzle-room-message', Template.currentData()._id
+
 Template.blackboard_round.helpers
   # the following is a map() instead of a direct find() to preserve order
   metas: ->
@@ -380,8 +384,6 @@ Template.blackboard_round.helpers
       puzzle = model.Puzzles.findOne({_id: id, solved: {$eq: null}, $or: [{feedsInto: {$size: 0}}, {puzzles: {$ne: null}}]})
       return true if puzzle?
     return false
-
-
 
 Template.blackboard_round.events
   'click .bb-round-buttons .bb-move-down': (event, template) ->
@@ -582,6 +584,8 @@ Template.blackboard_puzzle_cells.helpers
   solverMinutes: ->
     return unless @puzzle.solverTime?
     Math.floor(@puzzle.solverTime / 60000)
+  new_message: ->
+    not @puzzle.last_read_timestamp? or @puzzle.last_read_timestamp < @puzzle.last_message_timestamp
 
 colorHelper = -> model.getTag @, 'color'
 

--- a/client/imports/app_test_helpers.coffee
+++ b/client/imports/app_test_helpers.coffee
@@ -13,6 +13,9 @@ export waitForSubscriptions = -> new Promise (resolve) ->
       resolve()
   , 200
 
+export waitForMethods = -> new Promise (resolve) ->
+  Meteor.call 'wait', resolve
+
 # Tracker.afterFlush runs code when all consequent of a tracker based change
 #   (such as a route change) have occured. This makes it a promise.
 export afterFlushPromise = denodeify(Tracker.afterFlush)

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -99,12 +99,16 @@ if Meteor.isServer
 #     If unset/empty, use the order in the puzzles array.
 #     If 'name', alphabetically by name
 #   feedsInto: array of puzzle ids for metapuzzles this feeds into. Can be empty.
-#   if a has b in its feedsInto, then b should have a in its puzzles.
-#   This is kept denormalized because the lack of indexes in Minimongo would
-#   make it inefficient to query on the client, and because we want to control
-#   the order within a meta.
-#   Note that this allows arbitrarily many meta puzzles. Also, there is no
-#   requirement that a meta be fed only by puzzles in the same round.
+#     if a has b in its feedsInto, then b should have a in its puzzles.
+#     This is kept denormalized because the lack of indexes in Minimongo would
+#     make it inefficient to query on the client, and because we want to control
+#     the order within a meta.
+#     Note that this allows arbitrarily many meta puzzles. Also, there is no
+#     requirement that a meta be fed only by puzzles in the same round.
+#   last_message_timestamp: (synthetic, client only, optional) Timestamp of the
+#     last non-presence chat message in this puzzle's channel visible to you.
+#   last_read_timestamp: (synthetic, client only, optional) Your last read
+#      timestamp in this puzzle's channel.
 # If you add fields to this that should be visible on the client, also add them
 # to the fields map in puzzleQuery in server/server.coffee.
 Puzzles = BBCollection.puzzles = new Mongo.Collection "puzzles"

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -115,6 +115,31 @@ Meteor.publish 'settings', loginRequired -> Settings.find()
 
 Meteor.publish 'lastread', loginRequired (room_name) -> model.LastRead.find {nick: @userId, room_name}
 
+Meteor.publish 'last-puzzle-room-message', loginRequired (puzzle_id) ->
+  check puzzle_id, NonEmptyString
+  @added 'puzzles', puzzle_id, {}
+  lastChat = model.Messages.find 
+    room_name: "puzzles/#{puzzle_id}"
+    $or: [ {to: null}, {to: @userId}, {nick: @userId }]
+    deleted: $ne: true
+    presence: null
+  ,
+    fields: timestamp: 1
+    sort: timestamp: -1
+    limit: 1
+  .observe
+    added: (doc) => @changed 'puzzles', puzzle_id, {last_message_timestamp: doc.timestamp}
+  lastRead = model.LastRead.find
+    room_name: "puzzles/#{puzzle_id}"
+    nick: @userId
+  .observe
+    added: (doc) => @changed 'puzzles', puzzle_id, {last_read_timestamp: doc.timestamp}
+    changed: (doc) => @changed 'puzzles', puzzle_id, {last_read_timestamp: doc.timestamp}
+  @onStop ->
+    lastChat.stop()
+    lastRead.stop()
+  @ready()
+
 # this is for the "that was easy" sound effect
 # everyone is subscribed to this all the time
 Meteor.publish 'last-answered-puzzle', loginRequired ->

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -129,12 +129,13 @@ Meteor.publish 'last-puzzle-room-message', loginRequired (puzzle_id) ->
     limit: 1
   .observe
     added: (doc) => @changed 'puzzles', puzzle_id, {last_message_timestamp: doc.timestamp}
+  lastReadCallback = (doc) => @changed 'puzzles', puzzle_id, {last_read_timestamp: doc.timestamp}
   lastRead = model.LastRead.find
     room_name: "puzzles/#{puzzle_id}"
     nick: @userId
   .observe
-    added: (doc) => @changed 'puzzles', puzzle_id, {last_read_timestamp: doc.timestamp}
-    changed: (doc) => @changed 'puzzles', puzzle_id, {last_read_timestamp: doc.timestamp}
+    added: (doc) => lastReadCallback
+    changed: (doc) => lastReadCallback
   @onStop ->
     lastChat.stop()
     lastRead.stop()

--- a/server/setup.app-test.coffee
+++ b/server/setup.app-test.coffee
@@ -1,3 +1,5 @@
 'use strict'
 
 Accounts.removeDefaultRateLimit()
+
+Meteor.methods wait: ->


### PR DESCRIPTION
Adds a publish that inserts a last_message_timestamp and last_read_timestamp into the Puzzle object, and subscribes to it for favorite puzzles. It's shown in the "status" column for favorite puzzles.
Fixes #369