### PR TITLE
Reformat callin modal

### DIFF
--- a/blackboard.less
+++ b/blackboard.less
@@ -221,6 +221,13 @@ body.has-emojis {
   }
 }
 
+#callin_modal {
+  .controls {
+    .inline.radio { margin-right: 10px; }
+    .inline.radio + .inline.radio { margin-left: initial; }
+  }
+}
+
 @left-size: 85px;
 @right-size: 45px;
 @vert-padding: 4px;

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -197,6 +197,12 @@ callinTypesHelpers = (template) ->
       when callin_types.MESSAGE_TO_HQ then 'Message to HQ'
       when callin_types.EXPECTED_CALLBACK then 'Expected Callback'
       else ''
+    typeNameVerb: (type) -> switch (type ? Template.instance().type.get())
+      when callin_types.ANSWER then 'Answer to call in'
+      when callin_types.INTERACTION_REQUEST then 'Interaction to request'
+      when callin_types.MESSAGE_TO_HQ then 'Message to send HQ'
+      when callin_types.EXPECTED_CALLBACK then 'Callback to expect'
+      else ''
     tooltip: (type) -> switch type
       when callin_types.ANSWER then 'The solution to the puzzle. Fingers crossed!'
       when callin_types.INTERACTION_REQUEST then 'An intermediate string that may trigger a skit, physical puzzle, or creative challenge.'

--- a/puzzle.html
+++ b/puzzle.html
@@ -242,25 +242,38 @@ Request Call-In
     <h3>Request a call-in</h3>
   </div>
   <div class="modal-body">
-    <form class="form">
-      <label>{{typeName}} to call in:</label>
-      <input type="text" class="bb-callin-answer" placeholder="{{typeName}}">
-      <label>Callin Type</label>
-      {{#each callin_type in callinTypes}}
-        <label class="radio inline" title="{{tooltip callin_type}}">
-          <input type="radio" id="bb-callin-type-{{callin_type}}" value="{{callin_type}}" name="callin_type" checked="{{#unless @index}}checked{{/unless}}">
-          {{typeName callin_type}}
-        </label>
-      {{/each}}
+    <form class="form-horizontal">
+      <div class="control-group">
+        <label class="control-label">{{typeNameVerb}}:</label>
+        <div class="controls">
+          <input type="text" class="bb-callin-answer" id="bb-callin-answer" placeholder="{{typeName}}">
+        </div>
+      </div>
+      <div class="control-group">
+        <label class="control-label">Callin Type:</label>
+        <div class="controls">
+          {{#each callin_type in callinTypes}}
+            <label class="radio inline" title="{{tooltip callin_type}}">
+              <input type="radio" id="bb-callin-type-{{callin_type}}" value="{{callin_type}}" name="callin_type" checked="{{#unless @index}}checked{{/unless}}">
+              {{typeName callin_type}}
+            </label>
+          {{/each}}
+        </div>
+      </div>
       {{#if typeIs "answer"}}
-        <label class="checkbox" title="We derived this answer from a metapuzzle rather than the text of the puzzle itself.">
-          <input type="checkbox" value="backsolve"> Backsolved?
-        </label>
-        <label class="checkbox">
-          <input type="checkbox" value="provided"> Answer provided by HQ?
-          <!-- ie, because we brought a physical object to HQ, won a
-              game, or cashed in points -->
-        </label>
+        <div class="control-group">
+          <label class="control-label">Provenance</label>
+          <div class="controls">
+            <label class="checkbox" title="We derived this answer from a metapuzzle rather than the text of the puzzle itself.">
+              <input type="checkbox" value="backsolve"> Backsolved?
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" value="provided"> Answer provided by HQ?
+              <!-- ie, because we brought a physical object to HQ, won a
+                  game, or cashed in points -->
+            </label>
+          </div>
+        </div>
       {{/if}}
     </form>
   </div>


### PR DESCRIPTION
Uses form-horizontal and control groups to better separate callin type from source and so surprise wrapping of call-in types doesn't cause weird indenting.
Fixed #235 