### PR TITLE
Only stop propagation at the level of the filter dropdown menu

### DIFF
--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -140,7 +140,7 @@ Template.blackboard.helpers
 Template.blackboard.events
   'click .puzzle-working .button-group:not(.open) .bb-show-filter-by-user': (event, template) ->
     Meteor.defer -> template.find('.bb-filter-by-user').focus()
-  'click .puzzle-working .dropdown-menu *': (event, template) ->
+  'click .puzzle-working .dropdown-menu': (event, template) ->
     event.stopPropagation()
   'keyup .bb-filter-by-user': (event, template) ->
     return unless event.keyCode is 13


### PR DESCRIPTION
Stopping it for everything under the dropdown meant the X in the clear button was inactive.
Fixes #494