### PR TITLE
Fix flaky test for Drive change polling

### DIFF
--- a/server/imports/drive_change_polling.test.coffee
+++ b/server/imports/drive_change_polling.test.coffee
@@ -35,11 +35,15 @@ describe 'drive change polling', ->
     changes = sinon.mock(api.changes)
 
   afterEach ->
+    console.log 'about to stop poller'
     poller?.stop()
+    console.log 'about to restore clock'
     clock.restore()
     # Meteor uses underlying setTimeout for stuff, so you have to run any leftover timeouts
     # or it can break later tests.
+    console.log 'about to run all callbacks'
     clock.runAll()
+    console.log 'done'
 
   afterEach ->
     sinon.verifyAndRestore()

--- a/server/imports/drive_change_polling.test.coffee
+++ b/server/imports/drive_change_polling.test.coffee
@@ -42,7 +42,7 @@ describe 'drive change polling', ->
     # Meteor uses underlying setTimeout for stuff, so you have to run any leftover timeouts
     # or it can break later tests.
     console.log 'about to run all callbacks'
-    clock.runAll()
+    clock.tick(60000)
     console.log 'done'
 
   afterEach ->


### PR DESCRIPTION
Instead of faking setTimeout and clearTimeout, which tends to break Meteor as it uses them in the background, pass the object containing them to the constructor.
Fixes #493