### PR TITLE
Remove sha package

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -36,7 +36,6 @@ meteortesting:mocha
 fds:coffeescript-share
 xolvio:cleaner
 accounts-base@2.2.0
-sha@1.0.9
 underscore@1.0.10
 meteortesting:mocha-core
 facts-base@1.0.1

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -82,7 +82,6 @@ retry@1.1.0
 routepolicy@1.1.1
 service-configuration@1.3.0
 session@1.2.0
-sha@1.0.9
 shell-server@0.5.0
 socket-stream-client@0.4.0
 spacebars@1.2.0

--- a/client/imports/map.coffee
+++ b/client/imports/map.coffee
@@ -2,6 +2,7 @@
 
 import loader from "@googlemaps/js-api-loader"
 import mc from "@googlemaps/markerclusterer"
+import md5 from '/lib/imports/md5.coffee'
 export Loader = loader.Loader
 export MarkerClusterer = mc.MarkerClusterer
 
@@ -10,7 +11,7 @@ export positionOrDefault = (locatedAt, _id) ->
     coords = locatedAt.coordinates
     {lat: coords[1], lng: coords[0]}
   else
-    sha = SHA256 _id
+    sha = md5 _id
     lat_xtra = (parseInt(sha.substring(0,4), 16) - 32768) / 655360
     lng_xtra = (parseInt(sha.substring(4,8), 16) - 32768) / 655360
     {lat: lat_xtra + 30, lng: lng_xtra - 40}

--- a/client/imports/map.test.coffee
+++ b/client/imports/map.test.coffee
@@ -8,4 +8,4 @@ describe 'positionOrDefault', ->
     chai.assert.deepEqual positionOrDefault({type: 'Point', coordinates: [75.5, -20]}, 'sklanch'), {lat: -20, lng: 75.5}
 
   it 'randomizes unset position', ->
-    chai.assert.deepEqual positionOrDefault(undefined, 'sklanch'), {lat: 30.047036743164064, lng: -39.988528442382815}
+    chai.assert.deepEqual positionOrDefault(undefined, 'sklanch'), {lat: 29.957225036621093, lng: -40.023388671875}

--- a/client/imports/objectColor.coffee
+++ b/client/imports/objectColor.coffee
@@ -1,11 +1,12 @@
 'use strict'
 
-import { getTag } from '../../lib/imports/tags.coffee'
+import { getTag } from '/lib/imports/tags.coffee'
+import md5 from '/lib/imports/md5.coffee'
 import colornames from 'css-color-names'
 
 export default colorFromThingWithTags = (thing) ->
   getTag(thing, 'color') or do ->
-    hash = SHA256 thing._id
+    hash = md5 thing._id
     hue = parseInt(hash.substring(0, 4), 16) % 360
     saturation = ((parseInt(hash.substring(4, 6), 16)/ 255.0) ** 0.5) * 100
     lightness = ((parseInt(hash.substring(6, 8), 16) / 255.0) ** 0.5) * 50

--- a/client/imports/objectColor.test.coffee
+++ b/client/imports/objectColor.test.coffee
@@ -15,7 +15,7 @@ describe 'objectColor', ->
   it 'generates hsl from _id', ->
     obj =
       _id: 'u8JniQ2zqueSykCTm'
-    chai.assert.equal objectColor(obj), 'hsl(80, 41.06427291215469%, 37.18000727778937%)'
+    chai.assert.equal objectColor(obj), 'hsl(48, 82.60465732490333%, 20.291986247835695%)'
     
 describe 'cssColorToHex', ->
   it 'converts three-hex to six-hex', ->


### PR DESCRIPTION
Use md5 for generating psuedorandom colors and jittering map positions, since we don't need security.