### PR TITLE
Condensed status grid

### DIFF
--- a/blackboard.html
+++ b/blackboard.html
@@ -264,20 +264,17 @@
   <div class="bb-status-grid">
     {{#each rounds}}
       {{#each metas}}
-        <div class="bb-status-grid-meta-group" style="background-color: {{color}}">
+        <div class="bb-status-grid-meta-group" style="--meta-color: {{color}}">
           {{#let p=(puzzles puzzle.puzzles)}}
           {{#if puzzle.solved}}
-            {{>link class="bb-status-grid-meta" id=_id text=(abbrev puzzle.name)}}
-            <div class="bb-status-grid-puzzles">
-              <span class="bb-status-solved">{{numSolved p}}/{{p.length}}</span>
-              {{#each p}}
-                {{#unless puzzle.solved}}
-                  <span class="bb-status-{{#if stuck puzzle}}stuck{{else}}unsolved{{/if}}">
-                    {{>link id=puzzle._id title=puzzle.name text=(abbrev puzzle.name)}}
-                  </span>
-                {{/unless}}
-              {{/each}}
-            </div>
+            {{>link class="bb-status-grid-meta" id=_id title=puzzle.name text=(abbrev puzzle.name)}}
+            <span class="bb-status-grid-solved-count {{#if equal (numSolved p) p.length}}all-solved{{/if}}">{{numSolved p}}/{{p.length}}</span>
+            <div class="bb-status-grid-puzzles">{{#each p}}{{#unless puzzle.solved}}
+              {{! whitespace collapsed for :empty selector}}
+              <span class="bb-status-grid-cell bb-status-{{#if stuck puzzle}}stuck{{else}}unsolved{{/if}}">
+                {{>link id=puzzle._id title=puzzle.name text=puzzle_num}}
+              </span>
+            {{/unless}}{{/each}}</div>
           {{else}}
             {{>link class="bb-status-grid-meta" id=_id text=puzzle.name}}
             <div class="bb-status-grid-puzzles">
@@ -291,6 +288,22 @@
           {{/let}}
         </div>
       {{/each}}
+      {{#let u=unassigned}}
+      {{#if u.length}}
+        <div class="bb-status-grid-meta-group" style="--meta-color: var(--bg-color)">
+          {{#let p=(puzzles u)}}{{#let n=(numSolved p)}}
+            {{>link class="bb-status-grid-meta" id=_id title=name text=(abbrev name)}}
+            <span class="bb-status-grid-solved-count {{#if equal n p.length}}all-solved{{/if}}">{{n}}/{{p.length}}</span>
+            <div class="bb-status-grid-puzzles">{{#each p}}{{#unless puzzle.solved}}
+              {{! whitespace collapsed for :empty selector}}
+              <span class="bb-status-grid-cell bb-status-{{#if stuck puzzle}}stuck{{else}}unsolved{{/if}}">
+                {{>link id=puzzle._id title=puzzle.name text=puzzle_num}}
+              </span>
+            {{/unless}}{{/each}}</div>
+          {{/let}}{{/let}}
+        </div>
+      {{/if}}
+      {{/let}}
     {{/each}}
   </div><!-- bb-status-grid -->
 </template>

--- a/blackboard.html
+++ b/blackboard.html
@@ -262,34 +262,37 @@
 
 <template name="blackboard_status_grid">
   <div class="bb-status-grid">
-  <table>
-  <tbody>
     {{#each rounds}}
-    <tr><th colspan=2 class="bb-status-grid-round bb-status-{{#if solved}}solved{{else if stuck this}}stuck{{else}}unsolved{{/if}}">{{>link id=_id}}</th></tr>
       {{#each metas}}
-      <tr>
-        <td class="bb-status-grid-meta bb-status-{{#if puzzle.solved}}solved{{else if stuck puzzle}}stuck{{else}}unsolved{{/if}}">
-            {{>link id=puzzle._id}}
-        </td><td class="bb-status-grid-puzzles">
-        {{#each puzzles puzzle.puzzles}}<div class="bb-status-grid-cell bb-status-{{#if puzzle.solved}}solved{{else if stuck puzzle}}stuck{{else}}unsolved{{/if}}">
-            {{>link id=puzzle._id title=puzzle.name text=puzzle_num}}
-        </div>{{/each}}</td>
-      </tr>
+        <div class="bb-status-grid-meta-group" style="background-color: {{color}}">
+          {{#let p=(puzzles puzzle.puzzles)}}
+          {{#if puzzle.solved}}
+            {{>link class="bb-status-grid-meta" id=_id text=(abbrev puzzle.name)}}
+            <div class="bb-status-grid-puzzles">
+              <span class="bb-status-solved">{{numSolved p}}/{{p.length}}</span>
+              {{#each p}}
+                {{#unless puzzle.solved}}
+                  <span class="bb-status-{{#if stuck puzzle}}stuck{{else}}unsolved{{/if}}">
+                    {{>link id=puzzle._id title=puzzle.name text=(abbrev puzzle.name)}}
+                  </span>
+                {{/unless}}
+              {{/each}}
+            </div>
+          {{else}}
+            {{>link class="bb-status-grid-meta" id=_id text=puzzle.name}}
+            <div class="bb-status-grid-puzzles">
+              {{#each (puzzles puzzle.puzzles)}}
+                <span class="bb-status-grid-cell bb-status-{{#if puzzle.solved}}solved{{else if stuck puzzle}}stuck{{else}}unsolved{{/if}}">
+                  {{>link id=puzzle._id title=puzzle.name text=puzzle_num}}
+                </span>
+              {{/each}}
+            </div>
+          {{/if}}
+          {{/let}}
+        </div>
       {{/each}}
-      {{#with unassigned}}
-        {{#if this.length}}
-        <tr>
-          <td class="bb-status-grid-meta bb-status-unsolved">Unassigned</td>
-          <td class="bb-status-grid-puzzles">
-          {{#each puzzles this}}<div class="bb-status-grid-cell bb-status-{{#if puzzle.solved}}solved{{else if stuck puzzle}}stuck{{else}}unsolved{{/if}}">
-            {{>link id=puzzle._id title=puzzle.name text=puzzle_num}}
-          </div>{{/each}}</td>
-        </tr>
-        {{/if}}
-      {{/with}}
     {{/each}}
-  </tbody>
-  </table></div><!-- bb-status-grid -->
+  </div><!-- bb-status-grid -->
 </template>
 
 <template name="blackboard_othermeta_link">

--- a/blackboard.less
+++ b/blackboard.less
@@ -282,6 +282,8 @@ input[type=color] {
   position: relative;
   background: var(--bg-color);
   overflow-y: auto;
+  display: flex;
+  flex-flow: row wrap;
   @media(max-width: 980px) {
     margin-left: 0px;
     margin-right: 0px;
@@ -301,20 +303,28 @@ input[type=color] {
   padding: 5px;
   font-size: 80%;
 
-  .bb-status-grid-round {
-    font-weight: bold;
-    text-transform: uppercase;
-  }
-  td {
-    padding: 0px;
+  .bb-status-grid-meta-group {
+    display: flex;
+    flex-flow: row nowrap;
+    max-width: fit-content;
+    margin-right: 2px;
   }
   .bb-status-grid-meta {
     padding-right:2px;
+    background-color: var(--slightly-lighter);
+  }
+  .bb-status-grid-puzzles {
+    display: flex;
+    flex-flow: row wrap;
+    background-color: var(--much-lighter);
   }
   .bb-status-grid-cell {
     display: inline-block;
     width: 1.5em;
     text-align: center;
+  }
+  span:not(.bb-status-grid-cell) {
+    margin-right: 2px;
   }
   .bb-status-solved {
     background:#AAFF99;
@@ -324,9 +334,6 @@ input[type=color] {
   }
   .bb-status-stuck {
     background:var(--stuck-yellow);
-  }
-  .bb-status-unsolved {
-    background:var(--bg-color);
   }
 }
 

--- a/blackboard.less
+++ b/blackboard.less
@@ -307,24 +307,35 @@ input[type=color] {
     display: flex;
     flex-flow: row nowrap;
     max-width: fit-content;
-    margin-right: 2px;
+    margin-right: 4px;
+    margin-bottom: 2px;
+    border: 2px solid var(--meta-color);
+    background-color: var(--meta-color);
   }
   .bb-status-grid-meta {
-    padding-right:2px;
+    padding:0px 2px;
     background-color: var(--slightly-lighter);
   }
   .bb-status-grid-puzzles {
     display: flex;
     flex-flow: row wrap;
+    background-color: var(--bg-color);
+    margin-left: 1px;
+    &:empty {
+      display: none;
+    }
+  }
+  .bb-status-grid-solved-count {
     background-color: var(--much-lighter);
+    padding: 0px 2px;
+    &.all-solved {
+      background-color: var(--slightly-lighter);
+    }
   }
   .bb-status-grid-cell {
     display: inline-block;
     width: 1.5em;
     text-align: center;
-  }
-  span:not(.bb-status-grid-cell) {
-    margin-right: 2px;
   }
   .bb-status-solved {
     background:#AAFF99;

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -232,6 +232,7 @@ Template.blackboard.helpers
 Template.blackboard_status_grid.helpers
   rounds: round_helper
   metas: meta_helper
+  color: -> puzzleColor @puzzle if @puzzle?
   unassigned: -> 
     for id, index in this.puzzles
       puzzle = model.Puzzles.findOne({_id: id, feedsInto: {$size: 0}, puzzles: {$exists: false}})
@@ -244,6 +245,7 @@ Template.blackboard_status_grid.helpers
       puzzle: model.Puzzles.findOne(id) or { _id: id }
     } for id, index in ps)
     return p
+  numSolved: (l) -> l.filter((p) -> p.puzzle.solved).length
   stuck: share.model.isStuck
 
 Template.blackboard.onRendered ->

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -230,7 +230,7 @@ Template.blackboard.helpers
   driveFolder: -> Session.get 'RINGHUNTERS_FOLDER'
 
 Template.blackboard_status_grid.helpers
-  rounds: round_helper
+  rounds: -> model.Rounds.find {}, sort: [["sort_key", 'asc']]
   metas: meta_helper
   color: -> puzzleColor @puzzle if @puzzle?
   unassigned: -> 


### PR DESCRIPTION
By hiding solved puzzles in solved metas (replaced by a solved/total count) and using flex instead of a table, the entire hunt is visible in a much smaller height.
Fixes #528 