### PR TITLE
Standalone confirm dialog

### DIFF
--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -1,6 +1,7 @@
 'use strict'
 
 import canonical from '/lib/imports/canonical.coffee'
+import { confirm } from '/client/imports/modal.coffee'
 import { jitsiUrl } from './imports/jitsi.coffee'
 import puzzleColor, { cssColorToHex, hexToCssColor } from './imports/objectColor.coffee'
 import { HIDE_SOLVED, HIDE_SOLVED_FAVES, HIDE_SOLVED_METAS, MUTE_SOUND_EFFECTS, SORT_REVERSE, VISIBLE_COLUMNS } from './imports/settings.coffee'
@@ -322,12 +323,11 @@ Template.blackboard.events
       message += "this #{model.pretty_collection(type)}?"
     else
       message += "the #{rest[0]} of this #{model.pretty_collection(type)}?"
-    share.confirmationDialog
+    if (await confirm
       ok_button: 'Yes, delete it'
       no_button: 'No, cancel'
-      message: message
-      ok: ->
-        processBlackboardEdit[type]?(null, id, rest...) # process delete
+      message: message)
+      processBlackboardEdit[type]?(null, id, rest...) # process delete
   'click .bb-canEdit .bb-fix-drive': (event, template) ->
     event.stopPropagation() # keep .bb-editable from being processed!
     Meteor.call 'fixPuzzleFolder',

--- a/client/header.coffee
+++ b/client/header.coffee
@@ -400,26 +400,6 @@ Template.header_nickmodal_contents.events
           template.$("[data-argument=\"#{err.details.field}\"]").addClass 'error'
     return false
 
-############## confirmation dialog ########################
-Template.header_confirmmodal.helpers
-  confirmModalVisible: -> !!(Session.get 'confirmModalVisible')
-Template.header_confirmmodal_contents.onRendered ->
-  $('#confirmModal .bb-confirm-cancel').focus()
-  $('#confirmModal').modal show: true
-Template.header_confirmmodal_contents.events
-  "click .bb-confirm-ok": (event, template) ->
-    Template.header_confirmmodal_contents.cancel = false # do the thing!
-    $('#confirmModal').modal 'hide'
-
-confirmationDialog = share.confirmationDialog = (options) ->
-  $('#confirmModal').one 'hide', ->
-    Session.set 'confirmModalVisible', undefined
-    options.ok?() unless Template.header_confirmmodal_contents.cancel
-  # store away options before making dialog visible
-  Template.header_confirmmodal_contents.options = -> options
-  Template.header_confirmmodal_contents.cancel = true
-  Session.set 'confirmModalVisible', (options or Object.create(null))
-
 RECENT_GENERAL_LIMIT = 2
 
 ############## operation/chat log in header ####################

--- a/client/imports/modal.coffee
+++ b/client/imports/modal.coffee
@@ -1,0 +1,26 @@
+'use strict'
+
+Template.confirmmodal.onCreated ->
+  @result = @data.onCancel
+Template.confirmmodal.onRendered ->
+  @$('#confirmModal .bb-confirm-cancel').focus()
+  @$('#confirmModal').modal show: true
+Template.confirmmodal.events
+  "click .bb-confirm-ok": (event, template) ->
+    template.result = template.data.onConfirm
+    template.$('#confirmModal').modal 'hide'
+  'hidden *': (event, template) -> 
+    template.result()
+
+export confirm = (data) ->
+  new Promise (resolve) ->
+    view = null
+    onCancel = ->
+      share.Router.off 'route', onCancel
+      Blaze.remove view
+      resolve false
+    onConfirm = ->
+      share.Router.off 'route', onCancel
+      Blaze.remove view
+      resolve true
+    view = Blaze.renderWithData(Template.confirmmodal, {data..., onCancel, onConfirm}, document.body)

--- a/client/imports/modal.coffee
+++ b/client/imports/modal.coffee
@@ -16,11 +16,9 @@ export confirm = (data) ->
   new Promise (resolve) ->
     view = null
     onCancel = ->
-      share.Router.off 'route', onCancel
       Blaze.remove view
       resolve false
     onConfirm = ->
-      share.Router.off 'route', onCancel
       Blaze.remove view
       resolve true
     view = Blaze.renderWithData(Template.confirmmodal, {data..., onCancel, onConfirm}, document.body)

--- a/client/main.coffee
+++ b/client/main.coffee
@@ -419,8 +419,7 @@ BlackboardRouter = Backbone.Router.extend
       type: type
       id: id
     # cancel modals if they were active
-    $('#nickPickModal').modal 'hide'
-    $('#confirmModal').modal 'hide'
+    $('.modal').modal 'hide'
 
   urlFor: (type,id) ->
     Meteor._relativeToSiteRootUrl "/#{type}/#{id}"

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -1,6 +1,7 @@
 'use strict'
 
 import canonical from '/lib/imports/canonical.coffee'
+import { confirm } from '/client/imports/modal.coffee'
 import color from './imports/objectColor.coffee'
 import embeddable from './imports/embeddable.coffee'
 import * as callin_types from '/lib/imports/callin_types.coffee'
@@ -145,14 +146,13 @@ Template.puzzle_summon_button.helpers
 
 Template.puzzle_summon_button.events
   "click .bb-summon-btn.stuck": (event, template) ->
-    share.confirmationDialog
+    if (await confirm
       message: 'Are you sure you want to cancel this request for help?'
       ok_button: "Yes, this #{model.pretty_collection(Session.get 'type')} is no longer stuck"
-      no_button: 'Nevermind, this is still STUCK'
-      ok: ->
-        Meteor.call 'unsummon',
-          type: Session.get 'type'
-          object: Session.get 'id'
+      no_button: 'Nevermind, this is still STUCK')
+      Meteor.call 'unsummon',
+        type: Session.get 'type'
+        object: Session.get 'id'
   "click .bb-summon-btn.unstuck": (event, template) ->
     $('#summon_modal .stuck-at').val('at start')
     $('#summon_modal .stuck-need').val('ideas')

--- a/header.html
+++ b/header.html
@@ -328,26 +328,3 @@
     </div>
   {{/unless}}
 </template>
-
-<template name="header_confirmmodal">
-  <div class="modal hide" id="confirmModal">
-    {{! only insert contents if visible; this lets us manage
-        dependencies so we're not updating invisible content }}
-    {{#if confirmModalVisible}}{{> header_confirmmodal_contents }}{{/if}}
-  </div>
-</template>
-
-<template name="header_confirmmodal_contents">
-  <div class="modal-header">
-    <button type="button" class="close" data-dismiss="modal"
-            aria-hidden="true">&times;</button>
-    <h3>Are you sure?</h3>
-  </div>
-  <div class="modal-body">
-    <p>{{options.message}}</p>
-  </div>
-  <div class="modal-footer">
-    <button class="btn bb-confirm-ok">{{options.ok_button}}</button>
-    <button class="btn bb-confirm-cancel btn-primary" data-dismiss="modal" aria-hidden="true">{{options.no_button}}</button>
-  </div>
-</template>

--- a/modal.html
+++ b/modal.html
@@ -1,0 +1,16 @@
+<template name="confirmmodal">
+  <div class="modal hide" id="confirmModal">
+    <div class="modal-header">
+      <button type="button" class="close" data-dismiss="modal"
+              aria-hidden="true">&times;</button>
+      <h3>Are you sure?</h3>
+    </div>
+    <div class="modal-body">
+      <p>{{message}}</p>
+    </div>
+    <div class="modal-footer">
+      <button class="btn bb-confirm-ok">{{ok_button}}</button>
+      <button class="btn bb-confirm-cancel btn-primary" data-dismiss="modal" aria-hidden="true">{{no_button}}</button>
+    </div>
+  </div>
+</template>

--- a/page.html
+++ b/page.html
@@ -18,7 +18,6 @@
       <div id="bb-body" class="{{#if boringMode}}boring{{/if}}">
         {{> page }}
       </div>
-      {{> header_confirmmodal}}
     {{/if}}
   {{else}}
     {{> header_nickmodal_contents}}


### PR DESCRIPTION
Instead of having a global confirm dialog that's always in the page, add it to the dom when it's required and remove it when it's finished.