### PR TITLE
Editable components

### DIFF
--- a/blackboard.html
+++ b/blackboard.html
@@ -187,27 +187,16 @@
     {{#let m=metas u=unassigned}}
       <tbody>
       <tr><th colspan="{{nCols}}" id="round{{_id}}" class="bb-round-header {{#if collapsed}}collapsed{{/if}}">
-        <h2 class="bb-editable" data-bbedit="rounds//{{_id}}/title">
-        {{#if editing "rounds" "" _id "title"}}
-          <input type="text" id="rounds--{{_id}}-title"
-                value="{{name}}"
-                class="input-block-level" />
-        {{else}}
-          {{#if canEdit}}
-            {{#unless puzzles.length}}
-              <i class="bb-delete-icon fas fa-times pull-left"
-                title="Delete this round"></i>
-            {{/unless}}
-            <i class="bb-edit-icon fas fa-pencil-alt pull-right"
-              title="Edit the name of this round"></i>
-          {{else}}
-            <span class="collapse-toggle"></span>
-            {{>link id=_id title="Chat room for round" chat=true icon="fas fa-comments" class="pull-right bb-round-chat"}}
-            {{#if link}}<a class="pull-right bb-round-chat" target="_blank" href="{{link}}" title="Link to hunt site"><i class="fas fa-link"></i></a>{{/if}}
-          {{/if}}
-        {{name}}
-        {{/if}}
-        </h2>
+      {{#edit_object_title id=_id type="rounds" editable=canEdit}}
+        {{#unless puzzles.length}}
+          <i class="bb-delete-icon fas fa-times pull-left"
+            title="Delete this round"></i>
+        {{/unless}}
+      {{else}}
+        <span class="collapse-toggle"></span>
+        {{>link id=_id title="Chat room for round" chat=true icon="fas fa-comments" class="pull-right bb-round-chat"}}
+        {{#if link}}<a class="pull-right bb-round-chat" target="_blank" href="{{link}}" title="Link to hunt site"><i class="fas fa-link"></i></a>{{/if}}
+      {{/edit_object_title}}
       {{#unless compactMode}}{{>blackboard_tags}}{{/unless}}
       {{>blackboard_link}}
       {{#if canEdit}}
@@ -315,7 +304,7 @@
 
 <template name="blackboard_puzzle_cells">
   <td class="puzzle-name">
-    {{#edit_puzzle_title id=puzzle._id editable=canEdit}}
+    {{#edit_object_title id=puzzle._id type="puzzles" link_title=true editable=canEdit}}
       <i class="bb-delete-icon fas fa-times pull-left"
         title="Delete this puzzle"></i>
       {{#if any (equal puzzle.drive_status "failed") (equal puzzle.drive_status "skipped") (all (not puzzle.drive) (not puzzle.drive_status))}}
@@ -336,7 +325,7 @@
       {{#if puzzle.link}}<a class="pull-right" href="{{puzzle.link}}" target="_blank" title="Link to hunt site"><i class="fas fa-puzzle-piece"></i></a>{{/if}}
       {{#with jitsiLink}}<a class="pull-right" href="{{this}}" title="Link to video call" target="jitsi"><i class="fas fa-video"></i></a>{{/with}}
       {{>favorite puzzle}}
-    {{/edit_puzzle_title}}
+    {{/edit_object_title}}
     {{#if canEdit}}
       <div class="bb-puzzle-add-move" data-bbedit="puzzles/{{puzzle._id}}">
       <button class="btn btn-link bb-add-tag"

--- a/blackboard.html
+++ b/blackboard.html
@@ -197,8 +197,11 @@
         {{>link id=_id title="Chat room for round" chat=true icon="fas fa-comments" class="pull-right bb-round-chat"}}
         {{#if link}}<a class="pull-right bb-round-chat" target="_blank" href="{{link}}" title="Link to hunt site"><i class="fas fa-link"></i></a>{{/if}}
       {{/edit_object_title}}
-      {{#unless compactMode}}{{>blackboard_tags}}{{/unless}}
-      {{>blackboard_link}}
+      {{#unless compactMode}}
+        {{#blackboard_tags}}
+        {{#if canEdit}}<tr><td>Hunt site URL</td>{{>edit_field type="rounds" id=_id field="link"}}</tr>{{/if}}
+        {{/blackboard_tags}}
+      {{/unless}}
       {{#if canEdit}}
         <div class="bb-round-buttons" data-bbedit="rounds//{{_id}}">
           <div class="btn-group">
@@ -379,6 +382,7 @@
             </td>
           </tr>
           <tr><td>Mechanics:</td><td>{{> puzzle_mechanics}}</td></tr>
+          <tr><td>Hunt Site URL</td>{{>edit_field type="puzzles" id=_id field="link"}}</tr>
         {{else}}
           {{#with otherMetas}}
           <tr>
@@ -400,7 +404,6 @@
         {{>calendar_puzzle_cell}}
       {{/blackboard_tags}}
       {{/unless}}
-      {{>blackboard_link}}
     {{/with}}
   </td>
   {{#each column in visibleColumns}}
@@ -511,26 +514,4 @@
     {{/each}}
     {{> Template.contentBlock}}
   </tbody></table>
-</template>
-
-<template name="blackboard_link">
-{{#if canEdit}}
-  <table class="bb-tag-table"><tbody>
-    <tr>
-      <td>Hunt site link:</td>
-      <td class="bb-editable"
-          data-bbedit="link/{{../parent}}/{{_id}}">
-        {{#if editing "link" ../parent _id}}
-          <input type="text" id="link-{{../parent}}-{{_id}}"
-                  value="{{./link}}"
-                  class="input-block-level" />
-        {{else if canEdit}}
-          <a href="{{./link}}">{{./link}}</a>
-          <i class="bb-edit-icon fas fa-pencil-alt"
-              title="Change the value of the hunt site link"></i>
-        {{/if}}
-      </td>
-    </tr>
-  </tbody></table>
-{{/if}}
 </template>

--- a/blackboard.html
+++ b/blackboard.html
@@ -321,8 +321,6 @@
       {{#if any (equal puzzle.drive_status "failed") (equal puzzle.drive_status "skipped") (all (not puzzle.drive) (not puzzle.drive_status))}}
         <i class="fas fa-tools pull-right bb-fix-drive" title="Fix drive folder"></i>
       {{/if}}
-      <i class="bb-edit-icon fas fa-pencil-alt pull-right"
-          title="Edit the name of this puzzle"></i>
     {{else}}
       <span class="collapse-toggle"></span>
       {{#if equal puzzle.drive_status "creating"}}

--- a/blackboard.html
+++ b/blackboard.html
@@ -194,8 +194,10 @@
                 class="input-block-level" />
         {{else}}
           {{#if canEdit}}
-            <i class="bb-delete-icon fas fa-times pull-left"
-              title="Delete this round"></i>
+            {{#unless puzzles.length}}
+              <i class="bb-delete-icon fas fa-times pull-left"
+                title="Delete this round"></i>
+            {{/unless}}
             <i class="bb-edit-icon fas fa-pencil-alt pull-right"
               title="Edit the name of this round"></i>
           {{else}}

--- a/blackboard.html
+++ b/blackboard.html
@@ -434,11 +434,11 @@
 </template>
 
 <template name="blackboard_column_body_answer">
-  {{>edit_tag_value type="puzzles" id=puzzle._id name="Answer" value=answer editable=canEdit class="puzzle-answer answer"}}
+  {{>edit_tag_value type="puzzles" id=puzzle._id name="Answer" editable=canEdit class="puzzle-answer answer"}}
 </template>
 
 <template name="blackboard_column_body_status">
-  {{#edit_tag_value type="puzzles" id=puzzle._id name="Status" value=status editable=canEdit class="puzzle-status"}}
+  {{#edit_tag_value type="puzzles" id=puzzle._id name="Status" editable=canEdit class="puzzle-status"}}
     {{#if status}}<span class="bb-who-stuck">&mdash; by {{>gravatar nick=set_by size=12}}{{nickAndName set_by}}</span>{{/if}}
   {{/edit_tag_value}}
 </template>
@@ -531,7 +531,7 @@
     {{#each tags}}
     <tr data-tag-name="{{canon}}">
       {{>edit_tag_name type=type id=id name=name editable=canEdit}}
-      {{>edit_tag_value type=type id=id name=name value=value editable=canEdit}}
+      {{>edit_tag_value type=type id=id name=name editable=canEdit}}
     </tr>
     {{/each}}
     {{> Template.contentBlock}}

--- a/blackboard.html
+++ b/blackboard.html
@@ -398,9 +398,9 @@
             {{else if canEdit}}
               <i class="bb-delete-icon fas fa-times"
                   title="Delete this tag and value"></i>
-              <i class="bb-edit-icon fas fa-pencil-alt pull-right"
-                  title="Change the value of this tag"></i>
               {{value}}
+              <i class="bb-edit-icon fas fa-pencil-alt"
+                  title="Change the value of this tag"></i>
             {{else}}
               {{>text_chunks value}}
             {{/if}}
@@ -632,9 +632,9 @@
       {{else if canEdit}}
         <i class="bb-delete-icon fas fa-times pull-left"
            title="Delete this tag and value"></i>
-        <i class="bb-edit-icon fas fa-pencil-alt pull-right"
-           title="Edit the value of this tag"></i>
         {{value}}
+        <i class="bb-edit-icon fas fa-pencil-alt"
+           title="Edit the value of this tag"></i>
       {{else if value}}
         {{>text_chunks value}}
       {{else}}
@@ -656,9 +656,9 @@
                   value="{{./link}}"
                   class="input-block-level" />
         {{else if canEdit}}
-          <i class="bb-edit-icon fas fa-pencil-alt pull-right"
-              title="Change the value of the hunt site link"></i>
           <a href="{{./link}}">{{./link}}</a>
+          <i class="bb-edit-icon fas fa-pencil-alt"
+              title="Change the value of the hunt site link"></i>
         {{/if}}
       </td>
     </tr>

--- a/blackboard.html
+++ b/blackboard.html
@@ -314,40 +314,31 @@
 </template>
 
 <template name="blackboard_puzzle_cells">
-<td class="puzzle-name"><div>{{! div needed to establish relative pos }}
-  <div class="bb-editable bb-puzzle-title" data-bbedit="puzzles/{{parent}}/{{puzzle._id}}/title">
-    {{#if editing "puzzles" parent puzzle._id "title"}}
-      <input type="text" id="puzzles-{{parent}}-{{puzzle._id}}-title"
-              value="{{puzzle.name}}"
-              class="input-block-level" />
-    {{else}}
-      {{#if canEdit}}
-        <i class="bb-delete-icon fas fa-times pull-left"
-            title="Delete this puzzle"></i>
-        {{#if any (equal puzzle.drive_status "failed") (equal puzzle.drive_status "skipped") (all (not puzzle.drive) (not puzzle.drive_status))}}
-          <i class="fas fa-tools pull-right bb-fix-drive" title="Fix drive folder"></i>
-        {{/if}}
-        <i class="bb-edit-icon fas fa-pencil-alt pull-right"
-            title="Edit the name of this puzzle"></i>
-      {{else}}
-        <span class="collapse-toggle"></span>
-        {{#if equal puzzle.drive_status "creating"}}
-          <i class="pull-right fas fa-ellipsis-h bb-drive-status" title="creating..."></i>
-        {{else if equal puzzle.drive_status "failed"}}
-          <i class="pull-right fas fa-dumpster-fire bb-drive-status" title="Drive creation failed: {{puzzle.drive_error_message}}"></i>
-        {{else if equal puzzle.drive_status "fixing"}}
-          <i class="pull-right fas fa-tools bb-drive-status" title="fixing..."></i>
-        {{/if}}
-        {{#if puzzle.spreadsheet}}<a href="{{spread_link puzzle.spreadsheet}}" target="_blank" title="Spreadsheet for puzzle" class="pull-right"><i class="fas fa-th"></i></a>{{/if}}
-        {{#if puzzle.doc}}<a href="{{doc_link puzzle.doc}}" target="_blank" title="Doc for puzzle" class="pull-right"><i class="fas fa-file"></i></a>{{/if}}
-        {{>link id=puzzle._id title="Chat room for puzzle" chat=true class="pull-right" icon="fas fa-comments"}}
-        {{#if puzzle.link}}<a class="pull-right" href="{{puzzle.link}}" target="_blank" title="Link to hunt site"><i class="fas fa-puzzle-piece"></i></a>{{/if}}
-        {{#with jitsiLink}}<a class="pull-right" href="{{this}}" title="Link to video call" target="jitsi"><i class="fas fa-video"></i></a>{{/with}}
-        {{>favorite puzzle}}
+  <td class="puzzle-name">
+    {{#edit_puzzle_title id=puzzle._id editable=canEdit}}
+      <i class="bb-delete-icon fas fa-times pull-left"
+        title="Delete this puzzle"></i>
+      {{#if any (equal puzzle.drive_status "failed") (equal puzzle.drive_status "skipped") (all (not puzzle.drive) (not puzzle.drive_status))}}
+        <i class="fas fa-tools pull-right bb-fix-drive" title="Fix drive folder"></i>
       {{/if}}
-      {{>link id=puzzle._id editing=canEdit}}
-    {{/if}}
-    </div>
+      <i class="bb-edit-icon fas fa-pencil-alt pull-right"
+          title="Edit the name of this puzzle"></i>
+    {{else}}
+      <span class="collapse-toggle"></span>
+      {{#if equal puzzle.drive_status "creating"}}
+        <i class="pull-right fas fa-ellipsis-h bb-drive-status" title="creating..."></i>
+      {{else if equal puzzle.drive_status "failed"}}
+        <i class="pull-right fas fa-dumpster-fire bb-drive-status" title="Drive creation failed: {{puzzle.drive_error_message}}"></i>
+      {{else if equal puzzle.drive_status "fixing"}}
+        <i class="pull-right fas fa-tools bb-drive-status" title="fixing..."></i>
+      {{/if}}
+      {{#if puzzle.spreadsheet}}<a href="{{spread_link puzzle.spreadsheet}}" target="_blank" title="Spreadsheet for puzzle" class="pull-right"><i class="fas fa-th"></i></a>{{/if}}
+      {{#if puzzle.doc}}<a href="{{doc_link puzzle.doc}}" target="_blank" title="Doc for puzzle" class="pull-right"><i class="fas fa-file"></i></a>{{/if}}
+      {{>link id=puzzle._id title="Chat room for puzzle" chat=true class="pull-right" icon="fas fa-comments"}}
+      {{#if puzzle.link}}<a class="pull-right" href="{{puzzle.link}}" target="_blank" title="Link to hunt site"><i class="fas fa-puzzle-piece"></i></a>{{/if}}
+      {{#with jitsiLink}}<a class="pull-right" href="{{this}}" title="Link to video call" target="jitsi"><i class="fas fa-video"></i></a>{{/with}}
+      {{>favorite puzzle}}
+    {{/edit_puzzle_title}}
     {{#if canEdit}}
       <div class="bb-puzzle-add-move" data-bbedit="puzzles/{{puzzle._id}}">
       <button class="btn btn-link bb-add-tag"
@@ -424,7 +415,7 @@
       {{/unless}}
       {{>blackboard_link}}
     {{/with}}
-  </div></td>
+  </td>
   {{#each column in visibleColumns}}
     {{> Template.dynamic template=(concat "blackboard_column_body_" column._id)}}
   {{/each}}

--- a/blackboard.html
+++ b/blackboard.html
@@ -384,23 +384,18 @@
           {{/if}}
           <tr>
             <td>Feeds Into:</td>
-            <td class="bb-editable" data-bbedit="feedsInto/{{../parent}}/{{_id}}">
-              {{#if editing "feedsInto" ../parent _id}}
-                {{#each allMetas}}{{> blackboard_unfeed_meta puzzle=.. meta=this}}{{/each}}
-                {{#with unfedMetas}}{{#if this.count}}
-                  <div class="btn-group bb-feed-meta">
-                    <button class="btn btn-small dropdown-toggle" data-toggle="dropdown">
-                    Feed Meta <span class="caret"></span>
-                    </button>
-                    <ul class="dropdown-menu">
-                      {{#each this}}<li>{{> blackboard_addmeta_entry}}</li>{{/each}}
-                    </ul>
-                  </div>
-                {{/if}}{{/with}}
-              {{else}}
-                <span class="comma-list">{{#each allMetas}}{{> blackboard_othermeta_link}} {{else}}(none){{/each}}</span>
-                <i class="bb-edit-icon fas fa-pencil-alt"></i>
-              {{/if}}
+            <td>
+              <span class="comma-list">{{#each allMetas}}{{> blackboard_unfeed_meta puzzle=.. meta=this}} {{else}}(none){{/each}}</span>
+              {{#with unfedMetas}}{{#if this.count}}
+                <span class="btn-group bb-feed-meta">
+                  <button class="btn btn-mini dropdown-toggle" data-toggle="dropdown">
+                  Feed Meta <span class="caret"></span>
+                  </button>
+                  <ul class="dropdown-menu">
+                    {{#each this}}<li>{{> blackboard_addmeta_entry}}</li>{{/each}}
+                  </ul>
+                </span>
+              {{/if}}{{/with}}
             </td>
           </tr>
           <tr><td>Mechanics:</td><td>{{> puzzle_mechanics}}</td></tr>
@@ -475,10 +470,10 @@
 </template>
 
 <template name="blackboard_unfeed_meta">
-  <div>
+  <span>
     <i class="bb-unfeed-icon fas fa-times" title="Stop feeding this meta"></i>
     {{> blackboard_othermeta_link meta}}
-  </div>
+  </span>
 </template>
 
 <template name="blackboard_meta">

--- a/blackboard.html
+++ b/blackboard.html
@@ -203,7 +203,7 @@
         {{/blackboard_tags}}
       {{/unless}}
       {{#if canEdit}}
-        <div class="bb-round-buttons" data-bbedit="rounds//{{_id}}">
+        <div class="bb-round-buttons">
           <div class="btn-group">
             <button class="btn btn-mini btn-inverse bb-add-meta">
               <i class="fas fa-plus"></i>
@@ -330,7 +330,7 @@
       {{>favorite puzzle}}
     {{/edit_object_title}}
     {{#if canEdit}}
-      <div class="bb-puzzle-add-move" data-bbedit="puzzles/{{puzzle._id}}">
+      <div class="bb-puzzle-add-move">
       <button class="btn btn-link bb-add-tag"
             title="Add tag to puzzle">
         <i class="fas fa-tags"></i>
@@ -475,7 +475,7 @@
     {{/if}}
   {{#if canEdit}}
   <tr class="metafooter"><td colspan="{{nCols}}">
-    <div class="bb-meta-buttons" data-bbedit="puzzles/{{parent}}/{{puzzle._id}}">
+    <div class="bb-meta-buttons">
       <button class="btn btn-mini btn-inverse bb-add-puzzle">
         <i class="fas fa-plus"></i>
         Create new puzzle feeding this meta

--- a/blackboard.html
+++ b/blackboard.html
@@ -361,52 +361,7 @@
     {{/if}}
     {{#with puzzle}}
       {{#unless compactMode}}
-      <table class="bb-tag-table"><tbody>
-        {{#each tags}}
-        <tr>
-          <td class="bb-editable control-group {{tagEditClass}}"
-              data-bbedit="tags/{{../../parent}}/{{id}}/{{canon}}/name">
-            {{#if editing "tags" ../../parent id canon "name"}}
-              <input type="text" id="tags-{{../../parent}}-{{id}}-{{canon}}-name"
-                      value="{{name}}"
-                      class="input-block-level" />
-              {{#if tagEditStatus}}
-                <div class="tooltip right in bb-edit-status"><div class="tooltip-arrow"></div><div class="tooltip-inner">{{tagEditStatus}}</div></div>
-              {{/if}}
-            {{else}}
-              {{#if canEdit}}
-                <i class="bb-edit-icon fas fa-pencil-alt"
-                    title="Edit the name of this tag"></i>
-              {{/if}}
-              {{name}}:
-            {{/if}}
-          </td>
-          <td class="bb-editable"
-              data-bbedit="tags/{{../../parent}}/{{id}}/{{canon}}/value">
-            {{#if equal canon "color"}}
-              {{#if canEdit}}
-                <input type="color" id="tags-{{../../parent}}-{{id}}-{{canon}}-color"
-                       value="{{hexify value}}" />
-              {{else}}
-                <span class="bb-colorbox" style="background-color: {{value}}"></span>
-              {{/if}}
-            {{/if}}
-            {{#if editing "tags" ../../parent id canon "value"}}
-              <input type="text" id="tags-{{../../parent}}-{{id}}-{{canon}}-value"
-                      value="{{value}}"
-                      class="input-block-level" />
-            {{else if canEdit}}
-              <i class="bb-delete-icon fas fa-times"
-                  title="Delete this tag and value"></i>
-              {{value}}
-              <i class="bb-edit-icon fas fa-pencil-alt"
-                  title="Change the value of this tag"></i>
-            {{else}}
-              {{>text_chunks value}}
-            {{/if}}
-          </td>
-        </tr>
-        {{/each}}
+      {{#blackboard_tags}}
         {{#if canEdit}}
           {{#if canChangeMeta}}
           <tr>
@@ -468,8 +423,8 @@
           {{/if}}
         {{/if}}
         {{>calendar_puzzle_cell}}
-      </tbody></table>
-        {{/unless}}
+      {{/blackboard_tags}}
+      {{/unless}}
       {{>blackboard_link}}
     {{/with}}
   </div></td>
@@ -608,40 +563,38 @@
 </template>
 
 <template name="blackboard_tags">
-  <dl class="dl-horizontal">{{#each tags}}
-    <dt class="bb-editable"
-        data-bbedit="tags/{{../parent}}/{{id}}/{{canon}}/name">
-      {{#if editing "tags" ../parent id canon "name"}}
-        <input type="text" id="tags-{{../parent}}-{{id}}-{{canon}}-name"
-               value="{{name}}"
-               class="input-block-level" />
-      {{else}}
-        {{#if canEdit}}
-          <i class="bb-edit-icon fas fa-pencil-alt pull-left"
-             title="Edit the name of this tag"></i>
+  <table class="bb-tag-table"><tbody>
+    {{#each tags}}
+    <tr data-tag-name="{{canon}}">
+      {{>edit_tag_name type=type id=id name=name editable=canEdit}}
+      <td class="bb-editable"
+          data-bbedit="tags/{{../../parent}}/{{id}}/{{canon}}/value">
+        {{#if equal canon "color"}}
+          {{#if canEdit}}
+            <input type="color" id="tags-{{../../parent}}-{{id}}-{{canon}}-color"
+                    value="{{hexify value}}" />
+          {{else}}
+            <span class="bb-colorbox" style="background-color: {{value}}"></span>
+          {{/if}}
         {{/if}}
-        {{name}}:
-      {{/if}}
-     </dt>
-    <dd class="bb-editable"
-        data-bbedit="tags/{{../parent}}/{{id}}/{{canon}}/value">
-      {{#if editing "tags" ../parent id canon "value"}}
-        <input type="text" id="tags-{{../parent}}-{{id}}-{{canon}}-value"
-               value="{{value}}"
-               class="input-block-level" />
-      {{else if canEdit}}
-        <i class="bb-delete-icon fas fa-times pull-left"
-           title="Delete this tag and value"></i>
-        {{value}}
-        <i class="bb-edit-icon fas fa-pencil-alt"
-           title="Edit the value of this tag"></i>
-      {{else if value}}
-        {{>text_chunks value}}
-      {{else}}
-        &nbsp; {{! make sure right-hand side stays in place! }}
-      {{/if}}
-    </dd>
-  {{/each}}</dl>
+        {{#if editing "tags" ../../parent id canon "value"}}
+          <input type="text" id="tags-{{../../parent}}-{{id}}-{{canon}}-value"
+                  value="{{value}}"
+                  class="input-block-level" />
+        {{else if canEdit}}
+          <i class="bb-delete-icon fas fa-times"
+              title="Delete this tag and value"></i>
+          {{value}}
+          <i class="bb-edit-icon fas fa-pencil-alt"
+              title="Change the value of this tag"></i>
+        {{else}}
+          {{>text_chunks value}}
+        {{/if}}
+      </td>
+    </tr>
+    {{/each}}
+    {{> Template.contentBlock}}
+  </tbody></table>
 </template>
 
 <template name="blackboard_link">

--- a/blackboard.html
+++ b/blackboard.html
@@ -375,7 +375,7 @@
               {{/if}}
             {{else}}
               {{#if canEdit}}
-                <i class="bb-edit-icon fas fa-pencil-alt pull-left"
+                <i class="bb-edit-icon fas fa-pencil-alt"
                     title="Edit the name of this tag"></i>
               {{/if}}
               {{name}}:
@@ -396,7 +396,7 @@
                       value="{{value}}"
                       class="input-block-level" />
             {{else if canEdit}}
-              <i class="bb-delete-icon fas fa-times pull-left"
+              <i class="bb-delete-icon fas fa-times"
                   title="Delete this tag and value"></i>
               <i class="bb-edit-icon fas fa-pencil-alt pull-right"
                   title="Change the value of this tag"></i>

--- a/blackboard.html
+++ b/blackboard.html
@@ -434,49 +434,13 @@
 </template>
 
 <template name="blackboard_column_body_answer">
-  <td class="puzzle-answer bb-editable"
-      data-bbedit="tags/{{parent}}/{{puzzle._id}}/answer/value">
-    {{#if editing "tags" parent puzzle._id "answer" "value"}}
-      <input type="text" id="tags-{{parent}}-{{puzzle._id}}-answer-value"
-              value="{{answer}}"
-              class="input-block-level" />
-    {{else}}
-      {{#if canEdit}}
-        <i class="bb-edit-icon fas fa-pencil-alt pull-right"
-            title="Change the answer of this puzzle"></i>
-      {{/if}}
-      {{#if answer}}
-        {{#if canEdit}}
-          <i class="bb-delete-icon fas fa-times pull-left"
-              title="Delete the answer to this puzzle"></i>
-        {{/if}}
-        <span class="answer">{{answer}}</span>
-      {{/if}}
-    {{/if}}
-  </td>
+  {{>edit_tag_value type="puzzles" id=puzzle._id name="Answer" value=answer editable=canEdit class="puzzle-answer answer"}}
 </template>
 
 <template name="blackboard_column_body_status">
-  <td class="puzzle-status {{#unless puzzle.solved}}bb-editable{{/unless}}"
-      data-bbedit="tags/{{parent}}/{{puzzle._id}}/status/value">
-    {{#if editing "tags" parent puzzle._id "status" "value"}}
-      <input type="text" id="tags-{{parent}}-{{puzzle._id}}-status-value"
-              value="{{status}}"
-              class="input-block-level" />
-    {{else}}
-      {{#unless puzzle.solved}}
-      {{#if canEdit}}
-        <i class="bb-edit-icon fas fa-pencil-alt pull-right"
-            title="Change the status of this puzzle"></i>
-        {{#if status}}
-          <i class="bb-delete-icon fas fa-times pull-left"
-              title="Delete the status message for this puzzle"></i>
-        {{/if}}
-      {{/if}}
-      {{/unless}}
-      {{#if status}}{{status}} <span class="bb-who-stuck">&mdash; by {{>gravatar nick=set_by size=12}}{{nickAndName set_by}}</span>{{/if}}
-    {{/if}}
-  </td>
+  {{#edit_tag_value type="puzzles" id=puzzle._id name="Status" value=status editable=canEdit class="puzzle-status"}}
+    {{#if status}}<span class="bb-who-stuck">&mdash; by {{>gravatar nick=set_by size=12}}{{nickAndName set_by}}</span>{{/if}}
+  {{/edit_tag_value}}
 </template>
 
 <template name="blackboard_column_body_working">
@@ -567,30 +531,7 @@
     {{#each tags}}
     <tr data-tag-name="{{canon}}">
       {{>edit_tag_name type=type id=id name=name editable=canEdit}}
-      <td class="bb-editable"
-          data-bbedit="tags/{{../../parent}}/{{id}}/{{canon}}/value">
-        {{#if equal canon "color"}}
-          {{#if canEdit}}
-            <input type="color" id="tags-{{../../parent}}-{{id}}-{{canon}}-color"
-                    value="{{hexify value}}" />
-          {{else}}
-            <span class="bb-colorbox" style="background-color: {{value}}"></span>
-          {{/if}}
-        {{/if}}
-        {{#if editing "tags" ../../parent id canon "value"}}
-          <input type="text" id="tags-{{../../parent}}-{{id}}-{{canon}}-value"
-                  value="{{value}}"
-                  class="input-block-level" />
-        {{else if canEdit}}
-          <i class="bb-delete-icon fas fa-times"
-              title="Delete this tag and value"></i>
-          {{value}}
-          <i class="bb-edit-icon fas fa-pencil-alt"
-              title="Change the value of this tag"></i>
-        {{else}}
-          {{>text_chunks value}}
-        {{/if}}
-      </td>
+      {{>edit_tag_value type=type id=id name=name value=value editable=canEdit}}
     </tr>
     {{/each}}
     {{> Template.contentBlock}}

--- a/blackboard.less
+++ b/blackboard.less
@@ -154,9 +154,19 @@ body.has-emojis {
     color: #AAA;
   }
   .bb-right-content {
-    h1, h2, h3 {
+    h1, h2, h3, .bb-puzzle-title {
       font-size: 24px;
       line-height: 24px;
+    }
+    .bb-puzzle-title {
+      font-weight: bold;
+      & > input {
+        height: 18px;
+        line-height: 16px;
+        font-size: 16px;
+        font-weight: bold;
+        margin-top: 0;
+      }
     }
   }
   td.wanted { font-style: italic; }

--- a/blackboard.less
+++ b/blackboard.less
@@ -360,6 +360,7 @@ input[type=color] {
     margin-top: 2px;
     margin-bottom: 2px;
     min-height: auto;
+    min-width: 150px;
   }
 }
 .bb-canEdit {

--- a/blackboard.less
+++ b/blackboard.less
@@ -586,6 +586,7 @@ input[type="color"] {
         width: 0px;
         white-space: nowrap;
       }
+      .bb-edit-field { display: table-cell; }
       .bb-edit-icon {
         &.pull-left { margin-left: -6px; margin-right: 4px; }
         &.pull-right { margin-left: 2px; margin-right: -3px; }

--- a/blackboard.less
+++ b/blackboard.less
@@ -385,9 +385,6 @@ input[type="color"] {
 .bb-canEdit {
   /* adjust height of tags layout so that things don't shift badly when
    * the item is being edited (which uses a 24px input box) */
-  dt,dd {
-    &.bb-editable { min-height: 24px; }
-  }
   .bb-tag-table td.bb-editable { min-height: 24px; }
   /* tweak table column to make room for add tag/up/down icons */
   td.puzzle-name { padding-right: (14px)*3; }
@@ -488,21 +485,6 @@ input[type="color"] {
     i.fas {
       color: var(--text-color);
       margin-left: 2px;
-    }
-  }
-  dl {
-    margin: 0;
-    &:empty { display: none; }
-    dt {
-      .bb-edit-icon { margin-left: 3px; }
-    }
-    dd {
-      position: relative; /* fixes z-order, makes whole width clickable */
-      .bb-edit-icon { margin-right: 5px; }
-      .bb-delete-icon { margin-right: 3px; }
-    }
-    dt,dd {
-      .bb-edit-icon, .bb-delete-icon { margin-top: 3px; }
     }
   }
   tr.bb-status-stuck {

--- a/blackboard.less
+++ b/blackboard.less
@@ -535,6 +535,9 @@ input[type=color] {
     .bb-edit-icon, .bb-delete-icon, .bb-fix-drive, .bb-drive-status {
       margin-top: 3px;
     }
+    .bb-delete-icon:hover {
+      color: tomato;
+    }
     td .bb-delete-icon.pull-left {
       margin-left: 2px;
       margin-right: 3px;

--- a/blackboard.less
+++ b/blackboard.less
@@ -536,7 +536,7 @@ input[type=color] {
       margin-top: 3px;
     }
     td .bb-delete-icon.pull-left {
-      margin-left: -2px;
+      margin-left: 2px;
       margin-right: 3px;
     }
     .puzzle-name {

--- a/blackboard.less
+++ b/blackboard.less
@@ -209,7 +209,6 @@ body.has-emojis {
 }
 .bb-puzzle-info-tags {
   position: relative;
-  max-width: var(--right-column);
   td, .bb-edit-field {
     padding: 0px 0.5em;
     vertical-align: top;

--- a/blackboard.less
+++ b/blackboard.less
@@ -420,6 +420,12 @@ input[type=color] {
     font-size: 200%;
     .bb-edit-icon, .bb-delete-icon, { margin-top: 13px; }
   }
+  h2 > input {
+    font-weight: bold;
+    line-height: 30px;
+    height: 30px;
+    font-size: 30px;
+  }
   h3 {
     font-size: 130%;
     line-height: 28px;

--- a/blackboard.less
+++ b/blackboard.less
@@ -626,7 +626,7 @@ input[type="color"] {
     }
   }
 }
-.bb-delete-icon:hover {
+.bb-delete-icon:hover, .bb-unfeed-icon:hover {
   color: tomato;
 }
 

--- a/blackboard.less
+++ b/blackboard.less
@@ -376,7 +376,7 @@ input[type="color"] {
   }
   .bb-tag-table td.bb-editable { min-height: 24px; }
   /* tweak table column to make room for add tag/up/down icons */
-  td.puzzle-name > div { padding-right: (14px)*3; }
+  td.puzzle-name { padding-right: (14px)*3; }
 }
 .bb-show-filter-by-user + .dropdown-menu {
   left: unset;
@@ -541,15 +541,11 @@ input[type="color"] {
       margin-right: 3px;
     }
     .puzzle-name {
+      position: relative;
       .bb-favorite-button { float: right; }
-      & > div {
-        /* relative positioning context for .bb-puzzle-add-move.
-        * Note that firefox doesn't allow position: relative on a table cell */
-        position: relative;
-      }
       .bb-puzzle-add-move {
         display: block; width: 14px*3; height: 14px;
-        position: absolute; right: -2px; top: 3px;
+        position: absolute; right: 0px; top: 3px;
         .bb-add-tag, .bb-move-up, .bb-move-down {
           display: inline-block; width: 14px; height: 14px;
           position: relative;

--- a/blackboard.less
+++ b/blackboard.less
@@ -574,11 +574,16 @@ input[type=color] {
       }
     }
     .bb-tag-table {
+      width: 100%;
       font-size: 90%;
       border-collapse: collapse;
       position: relative;/* fixes z-order issues, makes whole width clickable */
       &, td, tr { border: none; }
       td { padding: 0 3px; margin: 0; }
+      td:first-child {
+        width: 0px;
+        white-space: nowrap;
+      }
       .bb-edit-icon {
         &.pull-left { margin-left: -6px; margin-right: 4px; }
         &.pull-right { margin-left: 2px; margin-right: -3px; }

--- a/blackboard.less
+++ b/blackboard.less
@@ -271,11 +271,14 @@ body.has-emojis {
 .bb-othermeta {
   display: inline-block;
 }
-input[type=color] {
+input[type="color"] {
   width: 14px;
   height: 14px;
   padding: 0px 0px;
   margin-right: 0.25em;
+  &::-webkit-color-swatch-wrapper {
+    padding: 2px;
+  }
 }
 
 .bb-top-right-content .bb-status-grid {
@@ -360,6 +363,8 @@ input[type=color] {
     margin-top: 2px;
     margin-bottom: 2px;
     min-height: auto;
+  }
+  input[type="text"] {
     min-width: 150px;
   }
 }
@@ -376,11 +381,6 @@ input[type=color] {
 .bb-show-filter-by-user + .dropdown-menu {
   left: unset;
   right: 0;
-}
-.bb-edit-status {
-  left: 100%;
-  top: -5px;
-  white-space: nowrap;
 }
 .can-collapse() {
   &.collapsed .bb-tag-table {
@@ -715,12 +715,6 @@ input[type=color] {
   .bb-omit-when-narrow, .puzzle-working, .puzzle-update { display: none !important; }
   .bb-buttonbar .bb-login { float: right }
   td.puzzle-answer { word-break: break-all; }
-
-  /* fix up .dl-horizontal styles */
-  #bb-tables dl {
-    dt { width: auto; display: inline-block; vertical-align: top; }
-    dd { margin-left: 0; display: inline-block; }
-  }
 
   #bb-body #bb-content > #bb-blackboard {
     padding-top: 0px;

--- a/blackboard.less
+++ b/blackboard.less
@@ -536,9 +536,6 @@ input[type="color"] {
     .bb-edit-icon, .bb-delete-icon, .bb-fix-drive, .bb-drive-status {
       margin-top: 3px;
     }
-    .bb-delete-icon:hover {
-      color: tomato;
-    }
     td .bb-delete-icon.pull-left {
       margin-left: 2px;
       margin-right: 3px;
@@ -628,6 +625,9 @@ input[type="color"] {
       }
     }
   }
+}
+.bb-delete-icon:hover {
+  color: tomato;
 }
 
 /* Responsive

--- a/blackboard.less
+++ b/blackboard.less
@@ -150,7 +150,7 @@ body.has-emojis {
     height: 500px;
     border-top: 1px solid #ccc;
   }
-  h2 {
+  h2, .bb-round-title {
     color: #AAA;
   }
   .bb-right-content {
@@ -427,27 +427,22 @@ input[type="color"] {
     margin-bottom: 0;
     text-align: center;
   }
-  h2 {
+  h2, .bb-round-title {
+    line-height: 40px;
     font-size: 200%;
-    .bb-edit-icon, .bb-delete-icon, { margin-top: 13px; }
-  }
-  h2 > input {
-    font-weight: bold;
-    line-height: 30px;
-    height: 30px;
-    font-size: 30px;
-  }
-  h3 {
-    font-size: 130%;
-    line-height: 28px;
-    .bb-edit-icon, .bb-delete-icon { margin-top: 7px; }
-  }
-  h2,h3 {
+    margin-top: 10px;
     margin-bottom: 0;
     position: relative; /* fixes z-order issues, makes whole width clickable */
     .bb-edit-icon, .bb-delete-icon {
+      margin-top: 13px; 
       &.pull-right { margin-right: 5px; }
       &.pull-left  { margin-left: 4px; margin-right: 3px; }
+    }
+    & > input {
+      font-weight: bold;
+      line-height: 30px;
+      height: 30px;
+      font-size: 27px;
     }
   }
   .bb-top-buttons {

--- a/blackboard.less
+++ b/blackboard.less
@@ -14,6 +14,10 @@
   src: local('Open Sans Emoji'), local('OpenSansEmoji'), url('../fonts/OpenSansEmoji.ttf') format('truetype');
 }
 
+@import '{}/client/imports/ui/components/edit_object_title/edit_object_title.less';
+@import '{}/client/imports/ui/components/edit_tag_name/edit_tag_name.less';
+@import '{}/client/imports/ui/components/edit_tag_value/edit_tag_value.less';
+
 .comma-list {
   & > *::after { content: ", "; }
   & > *:last-child::after { content:""; }

--- a/blackboard.less
+++ b/blackboard.less
@@ -209,9 +209,14 @@ body.has-emojis {
 }
 .bb-puzzle-info-tags {
   position: relative;
-  td {
+  max-width: var(--right-column);
+  td, .bb-edit-field {
     padding: 0px 0.5em;
     vertical-align: top;
+  }
+  .bb-edit-field { display: table-cell; }
+  [data-field="link"] a {
+    overflow-wrap: anywhere;
   }
   .bb-mechanics-dropdown {
     position: static;

--- a/callins.html
+++ b/callins.html
@@ -37,7 +37,7 @@
 </template>
 
 <template name="callin_row">
-  <tr data-bbedit="{{_id}}">
+  <tr>
     <td>{{>link id=target title="Chat room" chat=true icon="fas fa-comments" class="pull-right"}}{{>link target}}{{#if hunt_link}}
     <br/><small>&nbsp;↦&nbsp;<a href="{{hunt_link}}"
             target="_blank">on&nbsp;hunt&nbsp;site

--- a/client/blackboard.app-test.coffee
+++ b/client/blackboard.app-test.coffee
@@ -206,7 +206,7 @@ describe 'blackboard', ->
       await afterFlushPromise()
       chai.assert.isBelow cluelessJQ.offset().top, akaJQ.offset().top, 'after manual'
 
-    it 'allows creating puzzles with buttons', ->
+    it 'allows creating and deleting puzzles with buttons', ->
       share.Router.EditPage()
       await waitForSubscriptions()
       await afterFlushPromise()
@@ -244,6 +244,17 @@ describe 'blackboard', ->
       await afterFlushPromise()
       indirect = share.model.Puzzles.findOne name: 'Indirectly Created'
       chai.assert.include indirect.feedsInto, meta._id
+      $("[data-bbedit=\"puzzles/#{meta._id}/#{indirect._id}/title\"]").click()
+      await afterFlushPromise()
+      $("[data-bbedit=\"puzzles/#{meta._id}/#{indirect._id}/title\"] input").val('Creatively Undirected').focusout()
+      await waitForMethods()
+      chai.assert.include share.model.Puzzles.findOne(indirect._id), name: 'Creatively Undirected'
+      $("[data-bbedit=\"puzzles/#{meta._id}/#{indirect._id}/title\"] .bb-delete-icon").click()
+      await afterFlushPromise()
+      $('#confirmModal .bb-confirm-ok').click()
+      await waitForMethods()
+      chai.assert.isNotOk share.model.Puzzles.findOne indirect._id
+      
 
     it 'adds and deletes tags', ->
       share.Router.EditPage()

--- a/client/blackboard.app-test.coffee
+++ b/client/blackboard.app-test.coffee
@@ -237,9 +237,7 @@ describe 'blackboard', ->
       indirect = share.model.Puzzles.findOne name: 'Indirectly Created'
       chai.assert.isOk indirect, 'indirect'
       chai.assert.notInclude indirect.feedsInto, meta._id
-      $("#unassigned#{round._id} [data-bbedit=\"feedsInto/#{round._id}/#{indirect._id}\"]").click()
-      await afterFlushPromise()
-      $("#unassigned#{round._id} [data-bbedit=\"feedsInto/#{round._id}/#{indirect._id}\"] [data-puzzle-id=\"#{meta._id}\"]").click()
+      $("#unassigned#{round._id} tr.puzzle[data-puzzle-id=\"#{indirect._id}\"] .bb-feed-meta [data-puzzle-id=\"#{meta._id}\"]").click()
       await waitForMethods()
       await afterFlushPromise()
       indirect = share.model.Puzzles.findOne name: 'Indirectly Created'

--- a/client/blackboard.app-test.coffee
+++ b/client/blackboard.app-test.coffee
@@ -242,17 +242,16 @@ describe 'blackboard', ->
       await afterFlushPromise()
       indirect = share.model.Puzzles.findOne name: 'Indirectly Created'
       chai.assert.include indirect.feedsInto, meta._id
-      $("[data-bbedit=\"puzzles/#{meta._id}/#{indirect._id}/title\"]").click()
+      $("#m#{meta._id} tr.puzzle[data-puzzle-id=\"#{indirect._id}\"] .bb-puzzle-title").click()
       await afterFlushPromise()
-      $("[data-bbedit=\"puzzles/#{meta._id}/#{indirect._id}/title\"] input").val('Creatively Undirected').focusout()
+      $("#m#{meta._id} tr.puzzle[data-puzzle-id=\"#{indirect._id}\"] .bb-puzzle-title input").val('Creatively Undirected').focusout()
       await waitForMethods()
       chai.assert.include share.model.Puzzles.findOne(indirect._id), name: 'Creatively Undirected'
-      $("[data-bbedit=\"puzzles/#{meta._id}/#{indirect._id}/title\"] .bb-delete-icon").click()
+      $("#m#{meta._id} tr.puzzle[data-puzzle-id=\"#{indirect._id}\"] .bb-puzzle-title .bb-delete-icon").click()
       await afterFlushPromise()
       $('#confirmModal .bb-confirm-ok').click()
       await waitForMethods()
       chai.assert.isNotOk share.model.Puzzles.findOne indirect._id
-      
 
     it 'adds and deletes tags', ->
       share.Router.EditPage()

--- a/client/blackboard.app-test.coffee
+++ b/client/blackboard.app-test.coffee
@@ -252,7 +252,8 @@ describe 'blackboard', ->
       bank = -> share.model.Puzzles.findOne name: 'Letter Bank'
       initial = bank()
       chai.assert.notOk initial.tags.meme
-      $("[data-puzzle-id=\"#{initial._id}\"] .bb-add-tag").first().click()
+      baseJq = $("tbody.meta[data-puzzle-id=\"#{initial.feedsInto[1]}\"] [data-puzzle-id=\"#{initial._id}\"]")
+      baseJq.find('.bb-add-tag').first().click()
       fill_alertify 'Meme'
       creation = bank()
       await waitForMethods()
@@ -261,9 +262,9 @@ describe 'blackboard', ->
         value: ''
         touched_by: 'testy'
       await afterFlushPromise()
-      $("[data-bbedit=\"tags/#{initial.feedsInto[1]}/#{initial._id}/meme/value\"]").first().click()
+      baseJq.find('[data-tag-name="meme"] .bb-edit-tag-value').first().click()
       await afterFlushPromise()
-      $("[data-bbedit=\"tags/#{initial.feedsInto[1]}/#{initial._id}/meme/value\"] input").first().val('yuno accept deposits?').focusout()
+      baseJq.find('[data-tag-name="meme"] .bb-edit-tag-value input').first().val('yuno accept deposits?').focusout()
       await waitForMethods()
       edit = bank()
       chai.assert.include edit.tags.meme,
@@ -271,9 +272,9 @@ describe 'blackboard', ->
         value: 'yuno accept deposits?'
         touched_by: 'testy'
       await afterFlushPromise()
-      $("[data-bbedit=\"tags/#{initial.feedsInto[1]}/#{initial._id}/meme/value\"]").first().click()
+      baseJq.find('[data-tag-name="meme"] .bb-edit-tag-value').first().click()
       await afterFlushPromise()
-      $("[data-bbedit=\"tags/#{initial.feedsInto[1]}/#{initial._id}/meme/value\"] input").first().val('yuno pay interest?').trigger new $.Event('keydown', which: 27)
+      baseJq.find('[data-tag-name="meme"] .bb-edit-tag-value input').first().val('yuno pay interest?').trigger new $.Event('keydown', which: 27)
       await waitForMethods()
       # no edit on escape
       edit = bank()
@@ -282,9 +283,9 @@ describe 'blackboard', ->
         value: 'yuno accept deposits?'
         touched_by: 'testy'
       await afterFlushPromise()
-      $("[data-bbedit=\"tags/#{initial.feedsInto[1]}/#{initial._id}/meme/value\"]").first().click()
+      baseJq.find('[data-tag-name="meme"] .bb-edit-tag-value').first().click()
       await afterFlushPromise()
-      $("[data-bbedit=\"tags/#{initial.feedsInto[1]}/#{initial._id}/meme/value\"] input").first().val('yuno pay interest?').trigger new $.Event('keyup', which: 13)
+      baseJq.find('[data-tag-name="meme"] .bb-edit-tag-value input').first().val('yuno pay interest?').trigger new $.Event('keyup', which: 13)
       await waitForMethods()
       # Edit on enter
       edit = bank()
@@ -293,9 +294,9 @@ describe 'blackboard', ->
         value: 'yuno pay interest?'
         touched_by: 'testy'
       await afterFlushPromise()
-      $("[data-bbedit=\"tags/#{initial.feedsInto[1]}/#{initial._id}/meme/value\"]").first().click()
+      baseJq.find('[data-tag-name="meme"] .bb-edit-tag-value').first().click()
       await afterFlushPromise()
-      $("[data-bbedit=\"tags/#{initial.feedsInto[1]}/#{initial._id}/meme/value\"] input").first().val('').trigger new $.Event('keyup', which: 13)
+      baseJq.find('[data-tag-name="meme"] .bb-edit-tag-value input').first().val('').trigger new $.Event('keyup', which: 13)
       await waitForMethods()
       # empty cancels
       edit = bank()
@@ -304,7 +305,7 @@ describe 'blackboard', ->
         value: 'yuno pay interest?'
         touched_by: 'testy'
       await afterFlushPromise()
-      $("[data-bbedit=\"tags/#{initial.feedsInto[1]}/#{initial._id}/meme/value\"] .bb-delete-icon").first().click()
+      baseJq.find('[data-tag-name="meme"] .bb-edit-tag-value .bb-delete-icon').first().click()
       await afterFlushPromise()
       $("#confirmModal .bb-confirm-ok").click()
       await waitForMethods()
@@ -322,9 +323,9 @@ describe 'blackboard', ->
         name: 'color5'
         value: 'plurple'
       await afterFlushPromise()
-      $("[data-bbedit$=\"/#{disgust._id}/color5/name\"]").first().click()
+      $("[data-puzzle-id=\"#{disgust._id}\"] [data-tag-name=\"color5\"] .bb-edit-tag-name").first().click()
       await afterFlushPromise()
-      $("[data-bbedit$=\"/#{disgust._id}/color5/name\"] input").first().val('Color6').trigger new $.Event('keyup', which: 13)
+      $("[data-puzzle-id=\"#{disgust._id}\"] [data-tag-name=\"color5\"] .bb-edit-tag-name input").first().val('Color6').trigger new $.Event('keyup', which: 13)
       await waitForMethods()
       disgust = share.model.Puzzles.findOne disgust._id
       chai.assert.include disgust.tags.color6,
@@ -344,9 +345,9 @@ describe 'blackboard', ->
         name: 'color3'
         value: 'plurple'
       await afterFlushPromise()
-      $("[data-bbedit$=\"/#{disgust._id}/color3/name\"]").first().click()
+      $("[data-puzzle-id=\"#{disgust._id}\"] [data-tag-name=\"color3\"] .bb-edit-tag-name").first().click()
       await afterFlushPromise()
-      $("[data-bbedit$=\"/#{disgust._id}/color3/name\"] input").first().val('').trigger new $.Event('keyup', which: 13)
+      $("[data-puzzle-id=\"#{disgust._id}\"] [data-tag-name=\"color3\"] .bb-edit-tag-name input").first().val('').trigger new $.Event('keyup', which: 13)
       await waitForMethods()
       disgust = share.model.Puzzles.findOne disgust._id
       chai.assert.isOk disgust.tags.color3
@@ -362,9 +363,9 @@ describe 'blackboard', ->
         name: 'color2'
         value: 'plurple'
       await afterFlushPromise()
-      $("[data-bbedit$=\"/#{disgust._id}/color2/name\"]").first().click()
+      $("[data-puzzle-id=\"#{disgust._id}\"] [data-tag-name=\"color2\"] .bb-edit-tag-name").first().click()
       await afterFlushPromise()
-      $("[data-bbedit$=\"/#{disgust._id}/color2/name\"] input").first().val('color').trigger new $.Event('keyup', which: 13)
+      $("[data-puzzle-id=\"#{disgust._id}\"] [data-tag-name=\"color2\"] .bb-edit-tag-name input").first().val('color').trigger new $.Event('keyup', which: 13)
       await waitForMethods()
       disgust = share.model.Puzzles.findOne disgust._id
       chai.assert.isOk disgust.tags.color2

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -10,6 +10,7 @@ import { reactiveLocalStorage } from './imports/storage.coffee'
 import PuzzleDrag from './imports/puzzle_drag.coffee'
 import '/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee'
 import '/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee'
+import '/client/imports/ui/components/edit_object_title/edit_object_title.coffee'
 
 model = share.model # import
 settings = share.settings # import
@@ -388,15 +389,8 @@ Template.blackboard_unassigned.events
   'click tbody.unassigned tr.puzzle .bb-move-up': moveBeforePrevious.bind null, 'tr.puzzle', 'before'
   'click tbody.unassigned tr.puzzle .bb-move-down': moveAfterNext.bind null, 'tr.puzzle', 'after'
 processBlackboardEdit =
-  puzzles: (text, id, field) ->
-    processBlackboardEdit["puzzles_#{field}"]?(text, id)
   rounds: (text, id, field) ->
     processBlackboardEdit["rounds_#{field}"]?(text, id)
-  puzzles_title: (text, id) ->
-    if text is null # delete puzzle
-      Meteor.call 'deletePuzzle', id
-    else
-      Meteor.call 'renamePuzzle', {id:id, name:text}
   rounds_title: (text, id) ->
     if text is null # delete round
       Meteor.call 'deleteRound', id

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -2,7 +2,6 @@
 
 import canonical from '/lib/imports/canonical.coffee'
 import { confirm } from '/client/imports/modal.coffee'
-import okCancelEvents from '/client/imports/ok_cancel_events.coffee'
 import { jitsiUrl } from './imports/jitsi.coffee'
 import puzzleColor  from './imports/objectColor.coffee'
 import { HIDE_SOLVED, HIDE_SOLVED_FAVES, HIDE_SOLVED_METAS, MUTE_SOUND_EFFECTS, SORT_REVERSE, VISIBLE_COLUMNS } from './imports/settings.coffee'

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -296,19 +296,6 @@ Template.blackboard.events
     alertify.prompt "Name of new tag:", (e,str) =>
       return unless e # bail if cancelled
       Meteor.call 'setTag', {type:'puzzles', object: @puzzle._id, name:str, value:''}
-  "click .bb-canEdit .bb-delete-icon": (event, template) ->
-    event.stopPropagation() # keep .bb-editable from being processed!
-    [type, _parent, id, rest...] = share.find_bbedit(event)
-    message = "Are you sure you want to delete "
-    if (type is'tags') or (rest[0] is 'title')
-      message += "this #{model.pretty_collection(type)}?"
-    else
-      message += "the #{rest[0]} of this #{model.pretty_collection(type)}?"
-    if (await confirm
-      ok_button: 'Yes, delete it'
-      no_button: 'No, cancel'
-      message: message)
-      processBlackboardEdit[type]?(null, id, rest...) # process delete
   'click .bb-canEdit .bb-fix-drive': (event, template) ->
     event.stopPropagation() # keep .bb-editable from being processed!
     Meteor.call 'fixPuzzleFolder',
@@ -373,6 +360,13 @@ Template.blackboard_round.events
     reactiveLocalStorage.setItem "collapsed_round.#{template.data._id}", false
   'click .bb-round-header:not(.collapsed) .collapse-toggle': (event, template) ->
     reactiveLocalStorage.setItem "collapsed_round.#{template.data._id}", true
+  'click .bb-round-header .bb-delete-icon': (event, template) ->
+    event.stopPropagation()
+    if (await confirm
+      ok_button: 'Yes, delete it'
+      no_button: 'No, cancel'
+      message: "Are you sure you want to delete the round \"#{template.data.name}\"?")
+      Meteor.call 'deleteRound', template.data._id
 
 moveBeforePrevious = (match, rel, event, template) ->
   row = template.$(event.target).closest(match)
@@ -489,6 +483,14 @@ Template.blackboard_puzzle_cells.events
       type: 'puzzles'
       object: template.data.puzzle._id
       fields: order_by: event.currentTarget.dataset.sortOrder
+  'click .bb-puzzle-title .bb-delete-icon': (event, template) ->
+    event.stopPropagation()
+    if (await confirm
+      ok_button: 'Yes, delete it'
+      no_button: 'No, cancel'
+      message: "Are you sure you want to delete the puzzle \"#{template.data.puzzle.name}\"?")
+      Meteor.call 'deletePuzzle', template.data.puzzle._id
+
 
 tagHelper = ->
   isRound = not ('feedsInto' of this)

--- a/client/imports/ok_cancel_events.coffee
+++ b/client/imports/ok_cancel_events.coffee
@@ -1,0 +1,23 @@
+'use strict'
+
+# Returns an event map that handles the "escape" and "return" keys and
+# "blur" events on a text input (given by selector) and interprets them
+# as "ok" or "cancel".
+# (Borrowed from Meteor 'todos' example.)
+export default okCancelEvents = (selector, callbacks) ->
+  ok = callbacks.ok or (->)
+  cancel = callbacks.cancel or (->)
+  evspec = ("#{ev} #{selector}" for ev in ['keyup','keydown','focusout'])
+  events = {}
+  events[evspec.join(', ')] = (evt, template) ->
+    if evt.type is "keydown" and evt.which is 27
+      # escape = cancel
+      cancel.call this, evt, template
+    else if evt.type is "keyup" and evt.which is 13 or evt.type is "focusout"
+      # blur/return/enter = ok/submit if non-empty
+      value = String(evt.target.value or "")
+      if value
+        ok.call this, value, evt, template
+      else
+        cancel.call this, evt, template
+  events

--- a/client/imports/ok_cancel_events.coffee
+++ b/client/imports/ok_cancel_events.coffee
@@ -1,5 +1,28 @@
 'use strict'
 
+export editableTemplate = (template, callbacks) ->
+  template.onCreated ->
+    @editable = new ReactiveVar false
+
+  template.events
+    'click .bb-editable': (evt, t) ->
+      t.editable.set true
+      Tracker.afterFlush ->
+        t.$('input[type="text"]').focus()
+
+  template.events okCancelEvents 'input[type="text"]',
+    ok: (v, e, t) ->
+      return unless t.editable.get()
+      t.editable.set false
+      v = v.replace /^\s+|\s+$/, ''
+      callbacks.ok?(v, e, t)
+    cancel: (e, t) ->
+      t.editable.set false
+      callbacks.cancel?(e, t)
+
+  template.helpers
+    editing: -> Template.instance().editable.get()
+
 # Returns an event map that handles the "escape" and "return" keys and
 # "blur" events on a text input (given by selector) and interprets them
 # as "ok" or "cancel".

--- a/client/imports/ui/components/edit_field/edit_field.coffee
+++ b/client/imports/ui/components/edit_field/edit_field.coffee
@@ -1,30 +1,14 @@
 import './edit_field.html'
-import okCancelEvents from '/client/imports/ok_cancel_events.coffee'
+import { editableTemplate } from '/client/imports/ok_cancel_events.coffee'
 
-Template.edit_field.onCreated ->
-  @editing = new ReactiveVar false
-
-Template.edit_field.events
-  'click .bb-edit-field': (evt, template) ->
-    template.editing.set true
-    Tracker.afterFlush ->
-      template.$('input').focus()
-  
-Template.edit_field.events okCancelEvents 'input',
-  ok: (value, evt, tem) -> 
-    return unless tem.editing.get()
-    tem.editing.set false
-    # strip leading/trailing whitespace from text
-    value = value.replace /^\s+|\s+$/, ''
+editableTemplate Template.edit_field,
+  ok: (value, evt, tem) ->
     if value isnt share.model.collection(tem.data.type).findOne(tem.data.id)?[tem.data.field]
       Meteor.call 'setField',
         type: tem.data.type
         object: tem.data.id
         fields:
           [tem.data.field]: value
-  cancel: (evt, tem) ->
-    tem.editing.set false
 
 Template.edit_field.helpers
-  editing: -> Template.instance().editing.get()
   value: -> share.model.collection(@type).findOne(_id: @id)?[@field] ? ''

--- a/client/imports/ui/components/edit_field/edit_field.coffee
+++ b/client/imports/ui/components/edit_field/edit_field.coffee
@@ -1,0 +1,30 @@
+import './edit_field.html'
+import okCancelEvents from '/client/imports/ok_cancel_events.coffee'
+
+Template.edit_field.onCreated ->
+  @editing = new ReactiveVar false
+
+Template.edit_field.events
+  'click .bb-edit-field': (evt, template) ->
+    template.editing.set true
+    Tracker.afterFlush ->
+      template.$('input').focus()
+  
+Template.edit_field.events okCancelEvents 'input',
+  ok: (value, evt, tem) -> 
+    return unless tem.editing.get()
+    tem.editing.set false
+    # strip leading/trailing whitespace from text
+    value = value.replace /^\s+|\s+$/, ''
+    if value isnt share.model.collection(tem.data.type).findOne(tem.data.id)?[tem.data.field]
+      Meteor.call 'setField',
+        type: tem.data.type
+        object: tem.data.id
+        fields:
+          [tem.data.field]: value
+  cancel: (evt, tem) ->
+    tem.editing.set false
+
+Template.edit_field.helpers
+  editing: -> Template.instance().editing.get()
+  value: -> share.model.collection(@type).findOne(_id: @id)?[@field] ? ''

--- a/client/imports/ui/components/edit_field/edit_field.html
+++ b/client/imports/ui/components/edit_field/edit_field.html
@@ -1,0 +1,16 @@
+<template name="edit_field">
+  {{! Arguments:
+  type: object type
+  id: object id
+  field: field to edit
+  }}
+  <div class="bb-edit-field bb-editable" data-field="{{field}}" data-id="{{id}}" data-type="{{type}}">
+    {{#if editing}}
+      <input type="text" value="{{value}}" class="input-block-level" />
+    {{else}}
+      {{>text_chunks value}}
+      <i class="bb-edit-icon fas fa-pencil-alt"
+          title="Change the value of the hunt site link"></i>
+    {{/if}}
+  </div>
+</template>

--- a/client/imports/ui/components/edit_object_title/edit_object_title.coffee
+++ b/client/imports/ui/components/edit_object_title/edit_object_title.coffee
@@ -1,5 +1,4 @@
 import './edit_object_title.html'
-import './edit_object_title.less'
 import canonical from '/lib/imports/canonical.coffee'
 import { editableTemplate } from '/client/imports/ok_cancel_events.coffee'
 

--- a/client/imports/ui/components/edit_object_title/edit_object_title.coffee
+++ b/client/imports/ui/components/edit_object_title/edit_object_title.coffee
@@ -1,0 +1,44 @@
+import './edit_object_title.html'
+import './edit_object_title.less'
+import canonical from '/lib/imports/canonical.coffee'
+import okCancelEvents from '/client/imports/ok_cancel_events.coffee'
+
+Template.edit_puzzle_title.onCreated ->
+  @editing = new ReactiveVar false
+  @value = new ReactiveVar ''
+
+Template.edit_puzzle_title.events
+  'click .bb-editable': (event, template) ->
+    template.editing.set true
+    Tracker.afterFlush -> template.$('input').focus()
+  'input/focus input': (event, template) ->
+    template.value.set event.currentTarget.value
+
+Template.edit_puzzle_title.events okCancelEvents 'input',
+  ok: (val, evt, tem) ->
+    return unless tem.editing.get()
+    tem.editing.set false
+    if val isnt share.model.Puzzles.findOne(tem.data.id).name
+      Meteor.call 'renamePuzzle',
+        id: tem.data.id
+        name: val
+  cancel: (evt, tem) ->
+    tem.editing.set false
+  
+Template.edit_puzzle_title.helpers
+  name: -> share.model.Puzzles.findOne(@id).name
+  editing: -> Template.instance().editing.get()
+  titleEditClass: ->
+    val = Template.instance().value.get()
+    return 'error' if not val
+    cval = canonical val
+    return 'success' if cval is share.model.Puzzles.findOne(@id).canon
+    return 'error' if share.model.Puzzles.findOne(canon: cval)?
+    return 'success'
+  titleEditStatus: ->
+    val = Template.instance().value.get()
+    return 'Cannot be empty' if not val
+    return 'Unchanged' if val is share.model.Puzzles.findOne(@id).name
+    cval = canonical val
+    return if cval is share.model.Puzzles.findOne(@id).canon
+    return 'Conflicts with another puzzle' if share.model.Puzzles.findOne(canon: cval)?

--- a/client/imports/ui/components/edit_object_title/edit_object_title.coffee
+++ b/client/imports/ui/components/edit_object_title/edit_object_title.coffee
@@ -1,35 +1,26 @@
 import './edit_object_title.html'
 import './edit_object_title.less'
 import canonical from '/lib/imports/canonical.coffee'
-import okCancelEvents from '/client/imports/ok_cancel_events.coffee'
+import { editableTemplate } from '/client/imports/ok_cancel_events.coffee'
 
-Template.edit_object_title.onCreated ->
-  @editing = new ReactiveVar false
-  @value = new ReactiveVar ''
-
-Template.edit_object_title.events
-  'click .bb-editable': (event, template) ->
-    template.editing.set true
-    Tracker.afterFlush -> template.$('input').focus()
-  'input/focus input': (event, template) ->
-    template.value.set event.currentTarget.value
-
-Template.edit_object_title.events okCancelEvents 'input',
+editableTemplate Template.edit_object_title,
   ok: (val, evt, tem) ->
-    return unless tem.editing.get()
-    tem.editing.set false
     type = share.model.pretty_collection(tem.data.type)
     type = type[0].toUpperCase() + type.slice(1)
     if val isnt share.model.collection(tem.data.type).findOne(tem.data.id).name
       Meteor.call "rename#{type}",
         id: tem.data.id
         name: val
-  cancel: (evt, tem) ->
-    tem.editing.set false
+
+Template.edit_object_title.onCreated ->
+  @value = new ReactiveVar ''
+
+Template.edit_object_title.events
+  'input/focus input': (event, template) ->
+    template.value.set event.currentTarget.value
   
 Template.edit_object_title.helpers
   name: -> share.model.collection(@type).findOne(@id).name
-  editing: -> Template.instance().editing.get()
   pretty: -> share.model.pretty_collection(@type)
   titleEditClass: ->
     val = Template.instance().value.get()

--- a/client/imports/ui/components/edit_object_title/edit_object_title.coffee
+++ b/client/imports/ui/components/edit_object_title/edit_object_title.coffee
@@ -3,42 +3,45 @@ import './edit_object_title.less'
 import canonical from '/lib/imports/canonical.coffee'
 import okCancelEvents from '/client/imports/ok_cancel_events.coffee'
 
-Template.edit_puzzle_title.onCreated ->
+Template.edit_object_title.onCreated ->
   @editing = new ReactiveVar false
   @value = new ReactiveVar ''
 
-Template.edit_puzzle_title.events
+Template.edit_object_title.events
   'click .bb-editable': (event, template) ->
     template.editing.set true
     Tracker.afterFlush -> template.$('input').focus()
   'input/focus input': (event, template) ->
     template.value.set event.currentTarget.value
 
-Template.edit_puzzle_title.events okCancelEvents 'input',
+Template.edit_object_title.events okCancelEvents 'input',
   ok: (val, evt, tem) ->
     return unless tem.editing.get()
     tem.editing.set false
-    if val isnt share.model.Puzzles.findOne(tem.data.id).name
-      Meteor.call 'renamePuzzle',
+    type = share.model.pretty_collection(tem.data.type)
+    type = type[0].toUpperCase() + type.slice(1)
+    if val isnt share.model.collection(tem.data.type).findOne(tem.data.id).name
+      Meteor.call "rename#{type}",
         id: tem.data.id
         name: val
   cancel: (evt, tem) ->
     tem.editing.set false
   
-Template.edit_puzzle_title.helpers
-  name: -> share.model.Puzzles.findOne(@id).name
+Template.edit_object_title.helpers
+  name: -> share.model.collection(@type).findOne(@id).name
   editing: -> Template.instance().editing.get()
+  pretty: -> share.model.pretty_collection(@type)
   titleEditClass: ->
     val = Template.instance().value.get()
     return 'error' if not val
     cval = canonical val
-    return 'success' if cval is share.model.Puzzles.findOne(@id).canon
-    return 'error' if share.model.Puzzles.findOne(canon: cval)?
+    return 'info' if cval is share.model.collection(@type).findOne(@id).canon
+    return 'error' if share.model.collection(@type).findOne(canon: cval)?
     return 'success'
   titleEditStatus: ->
     val = Template.instance().value.get()
     return 'Cannot be empty' if not val
-    return 'Unchanged' if val is share.model.Puzzles.findOne(@id).name
+    return 'Unchanged' if val is share.model.collection(@type).findOne(@id).name
     cval = canonical val
-    return if cval is share.model.Puzzles.findOne(@id).canon
-    return 'Conflicts with another puzzle' if share.model.Puzzles.findOne(canon: cval)?
+    return if cval is share.model.collection(@type).findOne(@id).canon
+    return "Conflicts with another #{share.model.pretty_collection(@type)}" if share.model.collection(@type).findOne(canon: cval)?

--- a/client/imports/ui/components/edit_object_title/edit_object_title.html
+++ b/client/imports/ui/components/edit_object_title/edit_object_title.html
@@ -14,6 +14,8 @@
       {{/if}}
     {{else if editable}}
       {{>Template.contentBlock}}{{name}}
+      <i class="bb-edit-icon fas fa-pencil-alt pull-right"
+          title="Edit the name of this puzzle"></i>
     {{else}}
       {{>Template.elseBlock}}{{>link id=id tile="puzzles"}}
     {{/if}}

--- a/client/imports/ui/components/edit_object_title/edit_object_title.html
+++ b/client/imports/ui/components/edit_object_title/edit_object_title.html
@@ -1,0 +1,21 @@
+<template name="edit_puzzle_title">
+  {{! arguments:
+  id: puzzle id
+  editable: can the title be edited now?
+  content block: html to render inside the block while editable but not editing;
+                 it will be hidden while editing the title.
+  else block: html to render inside the block while not editable. It will be hidden when editable.
+  }}
+  <div class="bb-puzzle-title {{#if editable}}bb-editable{{/if}}{{#if editing}} control-group {{titleEditClass}}{{/if}}">
+    {{#if editing}}
+      <input type="text" value="{{name}}" class="input-block-level" />
+      {{#if titleEditStatus}}
+        <div class="tooltip bottom in bb-edit-status"><div class="tooltip-arrow"></div><div class="tooltip-inner">{{titleEditStatus}}</div></div>
+      {{/if}}
+    {{else if editable}}
+      {{>Template.contentBlock}}{{name}}
+    {{else}}
+      {{>Template.elseBlock}}{{>link id=id tile="puzzles"}}
+    {{/if}}
+  </div>
+</template>

--- a/client/imports/ui/components/edit_object_title/edit_object_title.html
+++ b/client/imports/ui/components/edit_object_title/edit_object_title.html
@@ -1,12 +1,14 @@
-<template name="edit_puzzle_title">
+<template name="edit_object_title">
   {{! arguments:
-  id: puzzle id
+  id: object id
+  type: object type (e.g. puzzles, rounds)
   editable: can the title be edited now?
+  link_title: if true, make puzzle title a link when not editing
   content block: html to render inside the block while editable but not editing;
                  it will be hidden while editing the title.
   else block: html to render inside the block while not editable. It will be hidden when editable.
   }}
-  <div class="bb-puzzle-title {{#if editable}}bb-editable{{/if}}{{#if editing}} control-group {{titleEditClass}}{{/if}}">
+  <div class="bb-{{pretty}}-title {{#if editable}}bb-editable{{/if}}{{#if editing}} control-group {{titleEditClass}}{{/if}}">
     {{#if editing}}
       <input type="text" value="{{name}}" class="input-block-level" />
       {{#if titleEditStatus}}
@@ -15,9 +17,9 @@
     {{else if editable}}
       {{>Template.contentBlock}}{{name}}
       <i class="bb-edit-icon fas fa-pencil-alt pull-right"
-          title="Edit the name of this puzzle"></i>
+          title="Edit the name of this {{pretty}}"></i>
     {{else}}
-      {{>Template.elseBlock}}{{>link id=id tile="puzzles"}}
+      {{>Template.elseBlock}}{{#if link_title}}{{>link id=id type=type}}{{else}}{{name}}{{/if}}
     {{/if}}
   </div>
 </template>

--- a/client/imports/ui/components/edit_object_title/edit_object_title.html
+++ b/client/imports/ui/components/edit_object_title/edit_object_title.html
@@ -16,7 +16,7 @@
       {{/if}}
     {{else if editable}}
       {{>Template.contentBlock}}{{name}}
-      <i class="bb-edit-icon fas fa-pencil-alt pull-right"
+      <i class="bb-edit-icon fas fa-pencil-alt"
           title="Edit the name of this {{pretty}}"></i>
     {{else}}
       {{>Template.elseBlock}}{{#if link_title}}{{>link id=id type=type}}{{else}}{{name}}{{/if}}

--- a/client/imports/ui/components/edit_object_title/edit_object_title.less
+++ b/client/imports/ui/components/edit_object_title/edit_object_title.less
@@ -1,5 +1,8 @@
 .bb-puzzle-title {
   position: relative;
+  &.control-group {
+    margin-bottom: 0;
+  }
   .bb-edit-status {
     top: 100%;
     white-space: nowrap;

--- a/client/imports/ui/components/edit_object_title/edit_object_title.less
+++ b/client/imports/ui/components/edit_object_title/edit_object_title.less
@@ -1,0 +1,7 @@
+.bb-puzzle-title {
+  position: relative;
+  .bb-edit-status {
+    top: 100%;
+    white-space: nowrap;
+  }
+}

--- a/client/imports/ui/components/edit_object_title/edit_object_title.less
+++ b/client/imports/ui/components/edit_object_title/edit_object_title.less
@@ -1,4 +1,4 @@
-.bb-puzzle-title {
+.bb-puzzle-title, .bb-round-title {
   position: relative;
   &.control-group {
     margin-bottom: 0;

--- a/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
+++ b/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
@@ -37,13 +37,16 @@ Template.edit_tag_name.helpers
     val = Template.instance().newTagName.get()
     return 'error' if not val
     cval = canonical val
-    return 'info' if cval is canonical @name
+    return 'info' if val is @name
+    return 'success' if cval is canonical @name
     return 'error' if share.model.collection(@type).findOne(_id: @id).tags[cval]?
     return 'success'
   tagEditStatus: ->
     val = Template.instance().newTagName.get()
     return 'Cannot be empty' if not val
     return 'Unchanged' if val is @name
-    return 'Tag already exists' if share.model.collection(@type).findOne(_id: @id).tags[canonical val]?
+    cval = canonical val
+    return if cval is canonical @name
+    return 'Tag already exists' if share.model.collection(@type).findOne(_id: @id).tags[cval]?
   canon: -> canonical @name
   editing: -> Template.instance().editing.get()

--- a/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
+++ b/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
@@ -4,7 +4,7 @@ import canonical from '/lib/imports/canonical.coffee'
 import { editableTemplate } from '/client/imports/ok_cancel_events.coffee'
 
 editableTemplate Template.edit_tag_name,
-  ok: (v, e, t) ->
+  ok: (val, evt, tem) ->
     if val
       thing = share.model.collection(tem.data.type).findOne(tem.data.id)
       canon = canonical @name

--- a/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
+++ b/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
@@ -11,7 +11,7 @@ Template.edit_tag_name.onCreated ->
 Template.edit_tag_name.events
   'input/focus input': (event, template) ->
     template.newTagName.set event.currentTarget.value
-  'click *': (event, template) ->
+  'click .bb-editable': (event, template) ->
     template.editing.set true
     Tracker.afterFlush ->
       template.$('input').focus()

--- a/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
+++ b/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
@@ -1,0 +1,50 @@
+import './edit_tag_name.html'
+import './edit_tag_name.less'
+
+import canonical from '/lib/imports/canonical.coffee'
+import okCancelEvents from '/client/imports/ok_cancel_events.coffee'
+
+Template.edit_tag_name.onCreated ->
+  @newTagName = new ReactiveVar @data.name
+  @editing = new ReactiveVar false
+
+Template.edit_tag_name.events
+  'input/focus input': (event, template) ->
+    template.newTagName.set event.currentTarget.value
+  'click *': (event, template) ->
+    template.editing.set true
+    Tracker.afterFlush ->
+      template.$('input').focus()
+
+Template.edit_tag_name.events okCancelEvents 'input',
+  ok: (val, evt, tem) ->
+    return unless tem.editing.get()
+    # strip leading/trailing whitespace from text (cancel if text is empty)
+    val = val.replace /^\s+|\s+$/, ''
+    if val
+      thing = share.model.collection(tem.data.type).findOne(tem.data.id)
+      canon = canonical @name
+      newCanon = canonical(val)
+      if newCanon isnt canon and thing.tags[newCanon]?
+        return
+      Meteor.call 'renameTag', {type:tem.data.type, object:tem.data.id, old_name:tem.data.name, new_name: val}
+    tem.editing.set false
+  cancel: (evt, tem) ->
+    console.log 'cancel'
+    tem.editing.set false
+
+Template.edit_tag_name.helpers
+  tagEditClass: ->
+    val = Template.instance().newTagName.get()
+    return 'error' if not val
+    cval = canonical val
+    return 'info' if cval is canonical @name
+    return 'error' if share.model.collection(@type).findOne(_id: @id).tags[cval]?
+    return 'success'
+  tagEditStatus: ->
+    val = Template.instance().newTagName.get()
+    return 'Cannot be empty' if not val
+    return 'Unchanged' if val is @name
+    return 'Tag already exists' if share.model.collection(@type).findOne(_id: @id).tags[canonical val]?
+  canon: -> canonical @name
+  editing: -> Template.instance().editing.get()

--- a/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
+++ b/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
@@ -1,5 +1,4 @@
 import './edit_tag_name.html'
-import './edit_tag_name.less'
 
 import canonical from '/lib/imports/canonical.coffee'
 import { editableTemplate } from '/client/imports/ok_cancel_events.coffee'

--- a/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
+++ b/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
@@ -2,26 +2,10 @@ import './edit_tag_name.html'
 import './edit_tag_name.less'
 
 import canonical from '/lib/imports/canonical.coffee'
-import okCancelEvents from '/client/imports/ok_cancel_events.coffee'
+import { editableTemplate } from '/client/imports/ok_cancel_events.coffee'
 
-Template.edit_tag_name.onCreated ->
-  @newTagName = new ReactiveVar @data.name
-  @editing = new ReactiveVar false
-
-Template.edit_tag_name.events
-  'input/focus input': (event, template) ->
-    template.newTagName.set event.currentTarget.value
-  'click .bb-editable': (event, template) ->
-    template.editing.set true
-    Tracker.afterFlush ->
-      template.$('input').focus()
-
-Template.edit_tag_name.events okCancelEvents 'input',
-  ok: (val, evt, tem) ->
-    return unless tem.editing.get()
-    tem.editing.set false
-    # strip leading/trailing whitespace from text (cancel if text is empty)
-    val = val.replace /^\s+|\s+$/, ''
+editableTemplate Template.edit_tag_name,
+  ok: (v, e, t) ->
     if val
       thing = share.model.collection(tem.data.type).findOne(tem.data.id)
       canon = canonical @name
@@ -29,8 +13,13 @@ Template.edit_tag_name.events okCancelEvents 'input',
       if newCanon isnt canon and thing.tags[newCanon]?
         return
       Meteor.call 'renameTag', {type:tem.data.type, object:tem.data.id, old_name:tem.data.name, new_name: val}
-  cancel: (evt, tem) ->
-    tem.editing.set false
+
+Template.edit_tag_name.onCreated ->
+  @newTagName = new ReactiveVar @data.name
+
+Template.edit_tag_name.events
+  'input/focus input': (event, template) ->
+    template.newTagName.set event.currentTarget.value
 
 Template.edit_tag_name.helpers
   tagEditClass: ->
@@ -49,4 +38,3 @@ Template.edit_tag_name.helpers
     return if cval is canonical @name
     return 'Tag already exists' if share.model.collection(@type).findOne(_id: @id).tags[cval]?
   canon: -> canonical @name
-  editing: -> Template.instance().editing.get()

--- a/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
+++ b/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
@@ -30,7 +30,6 @@ Template.edit_tag_name.events okCancelEvents 'input',
       Meteor.call 'renameTag', {type:tem.data.type, object:tem.data.id, old_name:tem.data.name, new_name: val}
     tem.editing.set false
   cancel: (evt, tem) ->
-    console.log 'cancel'
     tem.editing.set false
 
 Template.edit_tag_name.helpers

--- a/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
+++ b/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
@@ -7,7 +7,7 @@ editableTemplate Template.edit_tag_name,
   ok: (val, evt, tem) ->
     if val
       thing = share.model.collection(tem.data.type).findOne(tem.data.id)
-      canon = canonical @name
+      canon = canonical tem.data.name
       newCanon = canonical(val)
       if newCanon isnt canon and thing.tags[newCanon]?
         return

--- a/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
+++ b/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee
@@ -19,6 +19,7 @@ Template.edit_tag_name.events
 Template.edit_tag_name.events okCancelEvents 'input',
   ok: (val, evt, tem) ->
     return unless tem.editing.get()
+    tem.editing.set false
     # strip leading/trailing whitespace from text (cancel if text is empty)
     val = val.replace /^\s+|\s+$/, ''
     if val
@@ -28,7 +29,6 @@ Template.edit_tag_name.events okCancelEvents 'input',
       if newCanon isnt canon and thing.tags[newCanon]?
         return
       Meteor.call 'renameTag', {type:tem.data.type, object:tem.data.id, old_name:tem.data.name, new_name: val}
-    tem.editing.set false
   cancel: (evt, tem) ->
     tem.editing.set false
 

--- a/client/imports/ui/components/edit_tag_name/edit_tag_name.html
+++ b/client/imports/ui/components/edit_tag_name/edit_tag_name.html
@@ -1,0 +1,22 @@
+<template name="edit_tag_name">
+  {{! params:
+    type: object collection, eg. puzzles, rounds
+    id: object id
+    name: original name of tag
+    editable: Is the thing editable right now?
+  }}
+  <td class="bb-edit-tag-name {{#if editable}}bb-editable{{/if}} control-group {{tagEditClass}}">
+    {{#if editing}}
+      <input type="text" value="{{name}}" class="input-block-level" />
+      {{#if tagEditStatus}}
+        <div class="tooltip top in bb-edit-status"><div class="tooltip-arrow"></div><div class="tooltip-inner">{{tagEditStatus}}</div></div>
+      {{/if}}
+    {{else}}
+      {{#if editable}}
+        <i class="bb-edit-icon fas fa-pencil-alt"
+            title="Edit the name of this tag"></i>
+      {{/if}}
+      {{name}}:
+    {{/if}}
+  </td>
+</template>

--- a/client/imports/ui/components/edit_tag_name/edit_tag_name.html
+++ b/client/imports/ui/components/edit_tag_name/edit_tag_name.html
@@ -5,7 +5,7 @@
     name: original name of tag
     editable: Is the thing editable right now?
   }}
-  <td class="bb-edit-tag-name {{#if editable}}bb-editable{{/if}} control-group {{tagEditClass}}">
+  <td class="bb-edit-tag-name {{#if editable}}bb-editable{{/if}}{{#if editing}} control-group {{tagEditClass}}{{/if}}">
     {{#if editing}}
       <input type="text" value="{{name}}" class="input-block-level" />
       {{#if tagEditStatus}}

--- a/client/imports/ui/components/edit_tag_name/edit_tag_name.less
+++ b/client/imports/ui/components/edit_tag_name/edit_tag_name.less
@@ -2,7 +2,7 @@
   position: relative;
   white-space: nowrap;
 }
-.bb-puzzle-frame td.bb-edit-tag-name input {
+.bb-puzzle-info td.bb-edit-tag-name input {
   min-width: 100px;
 }
 .bb-edit-status {

--- a/client/imports/ui/components/edit_tag_name/edit_tag_name.less
+++ b/client/imports/ui/components/edit_tag_name/edit_tag_name.less
@@ -1,11 +1,11 @@
 .bb-edit-tag-name {
   position: relative;
   white-space: nowrap;
+  .bb-edit-status {
+    bottom: 100%;
+    white-space: nowrap;
+  }
 }
 .bb-puzzle-info td.bb-edit-tag-name input {
   min-width: 100px;
-}
-.bb-edit-status {
-  bottom: 100%;
-  white-space: nowrap;
 }

--- a/client/imports/ui/components/edit_tag_name/edit_tag_name.less
+++ b/client/imports/ui/components/edit_tag_name/edit_tag_name.less
@@ -1,0 +1,11 @@
+.bb-edit-tag-name {
+  position: relative;
+  white-space: nowrap;
+}
+.bb-puzzle-frame td.bb-edit-tag-name input {
+  min-width: 100px;
+}
+.bb-edit-status {
+  bottom: 100%;
+  white-space: nowrap;
+}

--- a/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee
+++ b/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee
@@ -1,0 +1,42 @@
+'use strict'
+import './edit_tag_value.html'
+import { confirm } from '/client/imports/modal.coffee'
+import { cssColorToHex, hexToCssColor } from '/client/imports/objectColor.coffee'
+import okCancelEvents from '/client/imports/ok_cancel_events.coffee'
+
+Template.edit_tag_value.onCreated ->
+  @editing = new ReactiveVar false
+
+Template.edit_tag_value.helpers
+  editing: -> Template.instance().editing.get()
+  hexify: (v) -> cssColorToHex v
+
+Template.edit_tag_value.events
+  'click input[type="color"]': (event, template) ->
+    event.stopPropagation()
+  'input input[type="color"]': (event, template) ->
+    text = hexToCssColor event.currentTarget.value
+    Meteor.call 'setTag', {type:template.data.type, object:template.data.id, name:template.data.name, value:text}
+  'click .bb-editable': (event, template) ->
+    template.editing.set true
+    Tracker.afterFlush ->
+      template.$('input[type="text"]').focus()
+  'click .bb-delete-icon': (event, template) ->
+    event.stopPropagation()
+    message = "Are you sure you want to delete the #{template.data.name}?"
+    if (await confirm
+      ok_button: 'Yes, delete it'
+      no_button: 'No, cancel'
+      message: message)
+      Meteor.call 'deleteTag', {type: template.data.type, object: template.data.id, name: template.data.name}
+
+Template.edit_tag_value.events okCancelEvents 'input[type="text"]',
+  ok: (value, evt, tem) -> 
+    return unless tem.editing.get()
+    # strip leading/trailing whitespace from text
+    value = value.replace /^\s+|\s+$/, ''
+    if value isnt tem.data.value
+      Meteor.call 'setTag', {type: tem.data.type, object: tem.data.id, name: tem.data.name, value}
+    tem.editing.set false
+  cancel: (evt, tem) ->
+    tem.editing.set false

--- a/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee
+++ b/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee
@@ -12,6 +12,7 @@ Template.edit_tag_value.onCreated ->
 Template.edit_tag_value.helpers
   canon: -> canonical @name
   value: -> share.model.collection(@type).findOne(_id: @id).tags[canonical @name]?.value ? ''
+  exists: -> share.model.collection(@type).findOne(_id: @id).tags[canonical @name]?
   editing: -> Template.instance().editing.get()
   hexify: (v) -> cssColorToHex v
 

--- a/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee
+++ b/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee
@@ -40,7 +40,7 @@ Template.edit_tag_value.events okCancelEvents 'input[type="text"]',
     return unless tem.editing.get()
     # strip leading/trailing whitespace from text
     value = value.replace /^\s+|\s+$/, ''
-    if value isnt tem.data.value
+    if value isnt share.model.collection(tem.data.type).findOne(tem.data.id)?.tags[canonical tem.data.name]?.value
       Meteor.call 'setTag', {type: tem.data.type, object: tem.data.id, name: tem.data.name, value}
     tem.editing.set false
   cancel: (evt, tem) ->

--- a/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee
+++ b/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee
@@ -27,7 +27,7 @@ Template.edit_tag_value.events
       template.$('input[type="text"]').focus()
   'click .bb-delete-icon': (event, template) ->
     event.stopPropagation()
-    message = "Are you sure you want to delete the #{template.data.name}?"
+    message = "Are you sure you want to delete the #{template.data.name} of #{share.model.collection(template.data.type).findOne(template.data.id).name}?"
     if (await confirm
       ok_button: 'Yes, delete it'
       no_button: 'No, cancel'

--- a/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee
+++ b/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee
@@ -1,5 +1,7 @@
 'use strict'
 import './edit_tag_value.html'
+
+import canonical from '/lib/imports/canonical.coffee'
 import { confirm } from '/client/imports/modal.coffee'
 import { cssColorToHex, hexToCssColor } from '/client/imports/objectColor.coffee'
 import okCancelEvents from '/client/imports/ok_cancel_events.coffee'
@@ -8,6 +10,7 @@ Template.edit_tag_value.onCreated ->
   @editing = new ReactiveVar false
 
 Template.edit_tag_value.helpers
+  canon: -> canonical @name
   editing: -> Template.instance().editing.get()
   hexify: (v) -> cssColorToHex v
 

--- a/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee
+++ b/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee
@@ -11,6 +11,7 @@ Template.edit_tag_value.onCreated ->
 
 Template.edit_tag_value.helpers
   canon: -> canonical @name
+  value: -> share.model.collection(@type).findOne(_id: @id).tags[canonical @name]?.value
   editing: -> Template.instance().editing.get()
   hexify: (v) -> cssColorToHex v
 

--- a/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee
+++ b/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee
@@ -11,7 +11,7 @@ Template.edit_tag_value.onCreated ->
 
 Template.edit_tag_value.helpers
   canon: -> canonical @name
-  value: -> share.model.collection(@type).findOne(_id: @id).tags[canonical @name]?.value
+  value: -> share.model.collection(@type).findOne(_id: @id).tags[canonical @name]?.value ? ''
   editing: -> Template.instance().editing.get()
   hexify: (v) -> cssColorToHex v
 

--- a/client/imports/ui/components/edit_tag_value/edit_tag_value.html
+++ b/client/imports/ui/components/edit_tag_value/edit_tag_value.html
@@ -3,7 +3,6 @@
     type: object collection, eg. puzzles, rounds
     id: object id
     name: name of tag
-    value: current value of tag
     editable: Is the thing editable right now?
     class: extra CSS classes to add
     content block: extra content when not editable

--- a/client/imports/ui/components/edit_tag_value/edit_tag_value.html
+++ b/client/imports/ui/components/edit_tag_value/edit_tag_value.html
@@ -1,0 +1,34 @@
+<template name="edit_tag_value">
+  {{! params:
+    type: object collection, eg. puzzles, rounds
+    id: object id
+    name: name of tag
+    value: current value of tag
+    editable: Is the thing editable right now?
+    class: extra CSS classes to add
+    content block: extra content when not editable
+  }}
+  <td class="{{class}} bb-edit-tag-value {{#if editable}}bb-editable{{/if}}">
+    {{#if equal canon "color"}}
+      {{#if editable}}
+        <input type="color" value="{{hexify value}}" />
+      {{else}}
+        <span class="bb-colorbox" style="background-color: {{value}}"></span>
+      {{/if}}
+    {{/if}}
+    {{#if editing}}
+      <input type="text" value="{{value}}" class="input-block-level" />
+    {{else}}
+      {{#if editable}}
+        <i class="bb-delete-icon fas fa-times"
+            title="Delete this tag and value"></i>
+        {{value}}
+        <i class="bb-edit-icon fas fa-pencil-alt"
+            title="Change the value of this tag"></i>
+      {{else}}
+        {{>text_chunks value}}
+      {{/if}}
+      {{>Template.contentBlock}}
+    {{/if}}
+  </td>
+</template>

--- a/client/imports/ui/components/edit_tag_value/edit_tag_value.html
+++ b/client/imports/ui/components/edit_tag_value/edit_tag_value.html
@@ -19,8 +19,10 @@
       <input type="text" value="{{value}}" class="input-block-level" />
     {{else}}
       {{#if editable}}
-        <i class="bb-delete-icon fas fa-times"
-            title="Delete this tag and value"></i>
+        {{#if exists}}
+          <i class="bb-delete-icon fas fa-times"
+              title="Delete this tag and value"></i>
+        {{/if}}
         {{value}}
         <i class="bb-edit-icon fas fa-pencil-alt"
             title="Change the value of this tag"></i>

--- a/client/imports/ui/components/edit_tag_value/edit_tag_value.less
+++ b/client/imports/ui/components/edit_tag_value/edit_tag_value.less
@@ -1,0 +1,9 @@
+#bb-tables .bb-puzzle .bb-tag-table [data-tag-name="color"] .bb-edit-tag-value {
+  position: relative;
+  --buffer: calc(14px + 0.25em);
+  padding-left: var(--buffer);
+  input[type="color"] {
+    position: absolute;
+    left: 0;
+  }
+}

--- a/client/imports/ui/components/edit_tag_value/edit_tag_value.less
+++ b/client/imports/ui/components/edit_tag_value/edit_tag_value.less
@@ -1,7 +1,6 @@
 #bb-tables .bb-puzzle .bb-tag-table [data-tag-name="color"] .bb-edit-tag-value {
   position: relative;
-  --buffer: calc(14px + 0.25em);
-  padding-left: var(--buffer);
+  padding-left: calc(14px + 0.25em);
   input[type="color"] {
     position: absolute;
     left: 0;

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -6,6 +6,7 @@ import color from './imports/objectColor.coffee'
 import embeddable from './imports/embeddable.coffee'
 import * as callin_types from '/lib/imports/callin_types.coffee'
 import '/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee'
+import '/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee'
 
 model = share.model # import
 settings = share.settings # import

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -5,6 +5,7 @@ import { confirm } from '/client/imports/modal.coffee'
 import color from './imports/objectColor.coffee'
 import embeddable from './imports/embeddable.coffee'
 import * as callin_types from '/lib/imports/callin_types.coffee'
+import '/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee'
 
 model = share.model # import
 settings = share.settings # import

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -5,6 +5,7 @@ import { confirm } from '/client/imports/modal.coffee'
 import color from './imports/objectColor.coffee'
 import embeddable from './imports/embeddable.coffee'
 import * as callin_types from '/lib/imports/callin_types.coffee'
+import '/client/imports/ui/components/edit_object_title/edit_object_title.coffee'
 import '/client/imports/ui/components/edit_tag_name/edit_tag_name.coffee'
 import '/client/imports/ui/components/edit_tag_value/edit_tag_value.coffee'
 

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -479,7 +479,7 @@ do ->
         [{$all: [id, args.before]}, $indexOfArray: ["$$npuzzles", args.before]]
       else if args.after?
         [{$all: [id, args.after]}, $add: [1, $indexOfArray: ["$$npuzzles", args.after]]]
-      res = Promise.await collection(parentType).rawCollection().updateOne({_id: parentId, puzzles: query}, [
+      res = await collection(parentType).rawCollection().updateOne({_id: parentId, puzzles: query}, [
         $set:
           puzzles: $let:
             vars: npuzzles: $filter: {input: "$puzzles", cond: $ne: ["$$this", id]}
@@ -493,13 +493,10 @@ do ->
           touched: UTCNow()
           touched_by: canonical(args.who)
       ])
-      if res.modifiedCount is 1
-        # Because we're not using Meteor's wrapper, we have to do this manually so the updated document is delivered by the subscription before the method returns.
-        Meteor.refresh {collection: parentType, id: parentId}
-        return true
+      return res.modifiedCount is 1
     catch e
       console.log e
-    return false
+      return false
       
   Meteor.methods
     newRound: (args) ->

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -515,6 +515,9 @@ do ->
       r
     renameRound: (args) ->
       check @userId, NonEmptyString
+      check args, ObjectWith
+        id: NonEmptyString
+        name: NonEmptyString
       renameObject "rounds", {args..., who: @userId}
       # TODO(torgen): rename default meta
     deleteRound: (id) ->

--- a/puzzle.html
+++ b/puzzle.html
@@ -1,5 +1,5 @@
 <template name="puzzle_info">
-<div class="bb-puzzle-frame">
+<div class="bb-puzzle-frame bb-canEdit">
 <div class="{{#if stuck}}bb-status-stuck{{else if puzzle.solved}}bb-status-solved{{/if}}">
   <h2>
     {{> header_breadcrumbs_unsolved_buttons puzzle}}
@@ -28,8 +28,8 @@
 {{/each}}
 {{#with puzzle}}
   {{#each tags}}
-    <tr>
-      <td class="tagname">{{name}}:</td>
+    <tr data-tag-name="{{name}}">
+      {{> edit_tag_name type="puzzles" id=../_id name=name editable=true}}
       <td class="tagvalue">
         {{#if equal canon "color"}}<span class="bb-colorbox" style="background-color: {{value}}"></span>{{/if}}
         {{>text_chunks value}}

--- a/puzzle.html
+++ b/puzzle.html
@@ -1,5 +1,5 @@
 <template name="puzzle_info">
-<div class="bb-puzzle-frame bb-canEdit">
+<div class="bb-puzzle-info bb-canEdit">
 <div class="{{#if stuck}}bb-status-stuck{{else if puzzle.solved}}bb-status-solved{{/if}}">
   <h2>
     {{> header_breadcrumbs_unsolved_buttons puzzle}}

--- a/puzzle.html
+++ b/puzzle.html
@@ -34,7 +34,7 @@
   {{#each tags}}
     <tr data-tag-name="{{name}}">
       {{> edit_tag_name type="puzzles" id=id name=name editable=true}}
-      {{> edit_tag_value type="puzzles" id=id name=name value=value editable=true}}
+      {{> edit_tag_value type="puzzles" id=id name=name editable=true}}
     </tr>
     {{#if equal canon 'status'}}
     <tr>

--- a/puzzle.html
+++ b/puzzle.html
@@ -18,6 +18,7 @@
     <tr><td class="backsolve">{{#if tag "backsolved"}}(backsolved){{/if}}</td><td class="timestamp">{{pretty_ts solved}}</td></tr>
   {{/if}}
   <tr><td>Mechanics:</td><td>{{> puzzle_mechanics}}{{#each mechanics}}<span class="label">{{mechanicName}}</span>{{/each}}</td></tr>
+  <tr><td>Hunt site URL:</td>{{>edit_field type="puzzles" id=_id field="link"}}</tr>
 {{/with}}
 {{#each cares in unsetcaredabout}}
   <tr data-tag-name={{cares.name}}>

--- a/puzzle.html
+++ b/puzzle.html
@@ -8,8 +8,7 @@
     {{#if puzzle.link}}<a href="{{puzzle.link}}" target="_blank" title="Open puzzle in new window"><i class="fas fa-link"></i></a>{{/if}}
     {{>calendar_attachable_events puzzle=puzzle._id}}
   </h2>
-  
-  <h1>{{puzzle.name}}</h1>
+  {{> edit_puzzle_title id=puzzle._id editable=true}}
 </div>
 {{>calendar_puzzle_events puzzle}}
 <table class="bb-puzzle-info-tags"><tbody>

--- a/puzzle.html
+++ b/puzzle.html
@@ -29,7 +29,7 @@
 {{#with puzzle}}
   {{#each tags}}
     <tr data-tag-name="{{name}}">
-      {{> edit_tag_name type="puzzles" id=../_id name=name editable=true}}
+      {{> edit_tag_name type="puzzles" id=id name=name editable=true}}
       <td class="tagvalue">
         {{#if equal canon "color"}}<span class="bb-colorbox" style="background-color: {{value}}"></span>{{/if}}
         {{>text_chunks value}}

--- a/puzzle.html
+++ b/puzzle.html
@@ -8,7 +8,7 @@
     {{#if puzzle.link}}<a href="{{puzzle.link}}" target="_blank" title="Open puzzle in new window"><i class="fas fa-link"></i></a>{{/if}}
     {{>calendar_attachable_events puzzle=puzzle._id}}
   </h2>
-  {{> edit_puzzle_title id=puzzle._id editable=true}}
+  {{> edit_object_title id=puzzle._id type="puzzles" editable=true}}
 </div>
 {{>calendar_puzzle_events puzzle}}
 <table class="bb-puzzle-info-tags"><tbody>

--- a/puzzle.html
+++ b/puzzle.html
@@ -21,7 +21,11 @@
   <tr><td>Mechanics:</td><td>{{> puzzle_mechanics}}{{#each mechanics}}<span class="label">{{mechanicName}}</span>{{/each}}</td></tr>
 {{/with}}
 {{#each cares in unsetcaredabout}}
-  <tr><td>{{cares.name}}:</td><td class="wanted">(wanted by <span title="{{cares.meta}}">{{abbrev cares.meta}}</span>)</td></tr>
+  <tr data-tag-name={{cares.name}}>
+    <td>{{cares.name}}:</td>
+    {{# edit_tag_value type="puzzles" id=puzzle._id name=cares.name editable=true}}
+      (wanted by <span title="{{cares.meta}}">{{abbrev cares.meta}}</span>)
+    {{/edit_tag_value}}</tr>
 {{/each}}
 {{#each mtag in metatags}}
   <tr><td>{{mtag.name}}:<br><i>(from <span title="{{mtag.meta}}">{{abbrev mtag.meta}}</span>)</i></td><td>{{>text_chunks mtag.value}}</td></tr>
@@ -30,10 +34,7 @@
   {{#each tags}}
     <tr data-tag-name="{{name}}">
       {{> edit_tag_name type="puzzles" id=id name=name editable=true}}
-      <td class="tagvalue">
-        {{#if equal canon "color"}}<span class="bb-colorbox" style="background-color: {{value}}"></span>{{/if}}
-        {{>text_chunks value}}
-      </td>
+      {{> edit_tag_value type="puzzles" id=id name=name value=value editable=true}}
     </tr>
     {{#if equal canon 'status'}}
     <tr>


### PR DESCRIPTION
Instead of the data-bbedit attribute and a handler on the blackboard template, make small templates that can each edit one kind of thing. Adds them to the puzzle info panel.
Fixes #567, Fixes #568