### PR TITLE
On-demand document embedding

### DIFF
--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -433,13 +433,12 @@ do ->
       spreadsheet: res.spreadId
     }
 
-  renameDriveFolder = (new_name, drive, spreadsheet, doc) ->
+  renameDriveFolder = (new_name, drive, spreadsheet) ->
     check new_name, NonEmptyString
     check drive, NonEmptyString
     check spreadsheet, Match.Optional(NonEmptyString)
-    check doc, Match.Optional(NonEmptyString)
     return unless Meteor.isServer
-    share.drive.renamePuzzle(new_name, drive, spreadsheet, doc)
+    share.drive.renamePuzzle(new_name, drive, spreadsheet)
 
   deleteDriveFolder = (drive) ->
     check drive, NonEmptyString

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -431,7 +431,6 @@ do ->
       drive_error_message: res.message
       drive: res.id
       spreadsheet: res.spreadId
-      doc: res.docId
     }
 
   renameDriveFolder = (new_name, drive, spreadsheet, doc) ->
@@ -540,10 +539,9 @@ do ->
       p = Puzzles.findOne args.id
       drive = p?.drive
       spreadsheet = p?.spreadsheet if drive?
-      doc = p?.doc if drive?
       result = renameObject "puzzles", {args..., who: @userId}
       # rename google drive folder
-      renameDriveFolder args.name, drive, spreadsheet, doc if result and drive?
+      renameDriveFolder args.name, drive, spreadsheet if result and drive?
       return result
     deletePuzzle: (pid) ->
       check @userId, NonEmptyString

--- a/server/imports/drive.coffee
+++ b/server/imports/drive.coffee
@@ -76,12 +76,6 @@ spreadsheetSettings =
     r.push SPREADSHEET_TEMPLATE
     r.push null
     r
-
-docSettings =
-  titleFunc: DOC_NAME
-  driveMimeType: GDRIVE_DOC_MIME_TYPE
-  uploadMimeType: 'text/plain'
-  uploadTemplate: -> 'Put notes here.'
   
 ensure = (drive, name, folder, settings) ->
   doc = (await drive.files.list
@@ -192,12 +186,10 @@ export class Drive
     {folder, permissionsPromise} = Promise.await ensureFolder @drive, name, @rootFolder
     # is the spreadsheet already there?
     spreadsheetP = ensure @drive, name, folder, spreadsheetSettings
-    docP = ensure @drive, name, folder, docSettings
-    [spreadsheet, doc, p] = Promise.await Promise.all [spreadsheetP, docP, permissionsPromise]
+    [spreadsheet, p] = Promise.await Promise.all [spreadsheetP, permissionsPromise]
     return {
       id: folder.id
       spreadId: spreadsheet.id
-      docId: doc.id
     }
 
   findPuzzle: (name) ->
@@ -208,17 +200,12 @@ export class Drive
     folder = resp.files[0]
     return null unless folder?
     # look for spreadsheet
-    spreadP = @drive.files.list
+    spread = Promise.await @drive.files.list
       q: "name=#{quote WORKSHEET_NAME name} and #{quote folder.id} in parents"
       pageSize: 1
-    docP = @drive.files.list
-      q: "name=#{quote DOC_NAME name} and #{quote folder.id} in parents"
-      pageSize: 1
-    [spread, doc] = Promise.await Promise.all [spreadP, docP]
     return {
       id: folder.id
       spreadId: spread.data.files[0]?.id
-      docId: doc.data.files[0]?.id
     }
 
   listPuzzles: ->
@@ -234,7 +221,7 @@ export class Drive
       break unless resp.nextPageToken?
     results
 
-  renamePuzzle: (name, id, spreadId, docId) ->
+  renamePuzzle: (name, id, spreadId) ->
     ps = [@drive.files.update
       fileId: id
       resource:
@@ -245,12 +232,6 @@ export class Drive
         fileId: spreadId
         resource:
           name: WORKSHEET_NAME name
-      )
-    if docId?
-      ps.push(@drive.files.update
-        fileId: docId
-        resource:
-          name: DOC_NAME name
       )
     Promise.await Promise.all ps
     'ok'

--- a/server/imports/drive.coffee
+++ b/server/imports/drive.coffee
@@ -11,7 +11,6 @@ DOC_NAME = (name) -> "Notes: #{name}"
 # Constants
 GDRIVE_FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder'
 GDRIVE_SPREADSHEET_MIME_TYPE = 'application/vnd.google-apps.spreadsheet'
-GDRIVE_DOC_MIME_TYPE = 'application/vnd.google-apps.document'
 XLSX_MIME_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 MAX_RESULTS = 200
 SPREADSHEET_TEMPLATE = Assets.getBinary 'spreadsheet-template.xlsx'

--- a/server/imports/drive.test.coffee
+++ b/server/imports/drive.test.coffee
@@ -177,33 +177,6 @@ describe 'drive', ->
               fileId: 'newsheet'
               resource: perm
             .resolves data: {}
-          files.expects('list').withArgs sinon.match
-            pageSize: 1
-            q: "name='Notes: New Puzzle' and mimeType='application/vnd.google-apps.document' and \'newpuzzle\' in parents"
-          .resolves data: files: []
-          doc = sinon.match
-            name: 'Notes: New Puzzle'
-            mimeType: 'application/vnd.google-apps.document'
-            parents: sinon.match.some sinon.match  'newpuzzle'
-          files.expects('create').withArgs sinon.match
-            resource: doc
-            media: sinon.match
-              mimeType: 'text/plain'
-              body: 'Put notes here.'
-          .resolves data:
-            id: 'newdoc'
-            name: 'Worksheet: New Puzzle'
-            mimeType: 'application/vnd.google-apps.document'
-            parents: ['newpuzzle']
-          permissions.expects('list').withArgs sinon.match
-            fileId: 'newdoc'
-            fields: PERMISSION_LIST_FIELDS
-          .resolves data: permissions: []
-          perms.forEach (perm) ->
-            permissions.expects('create').withArgs sinon.match
-              fileId: 'newdoc'
-              resource: perm
-            .resolves data: {}
           drive.createPuzzle 'New Puzzle'
 
         it 'returns existing', ->
@@ -233,19 +206,6 @@ describe 'drive', ->
             fileId: 'newsheet'
             fields: PERMISSION_LIST_FIELDS
           .resolves data: permissions: defaultPerms
-          files.expects('list').withArgs sinon.match
-            pageSize: 1
-            q: "name='Notes: New Puzzle' and mimeType='application/vnd.google-apps.document' and 'newpuzzle' in parents"
-          .resolves data: files: [
-            id: 'newdoc'
-            name: 'Notes: New Puzzle'
-            mimeType: 'application/vnd.google-apps.document'
-            parents: ['newpuzzle']
-          ]
-          permissions.expects('list').withArgs sinon.match
-            fileId: 'newdoc'
-            fields: PERMISSION_LIST_FIELDS
-          .resolves data: permissions: defaultPerms
           drive.createPuzzle 'New Puzzle'
 
       describe 'findPuzzle', ->
@@ -257,7 +217,7 @@ describe 'drive', ->
           .resolves data: files: []
           chai.assert.isNull drive.findPuzzle 'New Puzzle'
         
-        it 'returns spreadsheet and doc', ->
+        it 'returns spreadsheet', ->
           files.expects('list').withArgs sinon.match 
             q: 'name=\'New Puzzle\' and mimeType=\'application/vnd.google-apps.folder\' and \'hunt\' in parents'
             pageSize: 1
@@ -277,19 +237,9 @@ describe 'drive', ->
             mimeType: 'application/vnd.google-apps.spreadsheet'
             parents: ['newpuzzle']
           ]
-          files.expects('list').withArgs sinon.match
-            pageSize: 1
-            q: "name='Notes: New Puzzle' and 'newpuzzle' in parents"
-          .resolves data: files: [
-            id: 'newdoc'
-            name: 'Notes: New Puzzle'
-            mimeType: 'application/vnd.google-apps.document'
-            parents: ['newpuzzle']
-          ]
           chai.assert.include drive.findPuzzle('New Puzzle'),
             id: 'newpuzzle'
             spreadId: 'newsheet'
-            docId: 'newdoc'
 
       it 'listPuzzles returns list', ->
         item1 =
@@ -326,11 +276,7 @@ describe 'drive', ->
           fileId: 'newsheet'
           resource: sinon.match name: 'Worksheet: Old Puzzle'
         .resolves data: {}
-        files.expects('update').withArgs sinon.match
-          fileId: 'newdoc'
-          resource: sinon.match name: 'Notes: Old Puzzle'
-        .resolves data: {}
-        drive.renamePuzzle 'Old Puzzle', 'newpuzzle', 'newsheet', 'newdoc'
+        drive.renamePuzzle 'Old Puzzle', 'newpuzzle', 'newsheet',
 
       it 'deletePuzzle deletes', ->
         files.expects('list').withArgs sinon.match

--- a/server/methods/newPuzzle.test.coffee
+++ b/server/methods/newPuzzle.test.coffee
@@ -23,7 +23,6 @@ describe 'newPuzzle', ->
       createPuzzle: sinon.fake.returns
         id: 'fid' # f for folder
         spreadId: 'sid'
-        docId: 'did'
       renamePuzzle: sinon.spy()
       deletePuzzle: sinon.spy()
     if share.drive?
@@ -78,7 +77,6 @@ describe 'newPuzzle', ->
         link: 'https://puzzlehunt.mit.edu/foo'
         drive: 'fid'
         spreadsheet: 'sid'
-        doc: 'did'
         tags: {}
 
     it 'adds puzzle to round', ->
@@ -147,7 +145,6 @@ describe 'newPuzzle', ->
       link: 'https://testhuntpleaseign.org/puzzles/foo-puzzle'
       drive: 'fid'
       spreadsheet: 'sid'
-      doc: 'did'
       tags: {}
 
   describe 'when one exists with that name', ->
@@ -167,7 +164,6 @@ describe 'newPuzzle', ->
         link: 'https://puzzlehunt.mit.edu/foo'
         drive: 'fid'
         spreadsheet: 'sid'
-        doc: 'did'
         tags: {}
       round = model.Rounds.insert
         name: 'Round'

--- a/server/methods/renamePuzzle.test.coffee
+++ b/server/methods/renamePuzzle.test.coffee
@@ -21,7 +21,6 @@ describe 'renamePuzzle', ->
       createPuzzle: sinon.fake.returns
         id: 'fid' # f for folder
         spreadId: 'sid'
-        docId: 'did'
       renamePuzzle: sinon.spy()
       deletePuzzle: sinon.spy()
     if share.drive?
@@ -51,7 +50,6 @@ describe 'renamePuzzle', ->
         link: 'https://puzzlehunt.mit.edu/foo'
         drive: 'fid'
         spreadsheet: 'sid'
-        doc: 'did'
         tags: {}
 
     it 'fails without login', ->
@@ -80,7 +78,7 @@ describe 'renamePuzzle', ->
           touched_by: 'cjb'
       
       it 'renames drive', ->
-        chai.assert.deepEqual driveMethods.renamePuzzle.getCall(0).args, ['Bar', 'fid', 'sid', 'did']
+        chai.assert.deepEqual driveMethods.renamePuzzle.getCall(0).args, ['Bar', 'fid', 'sid']
 
       it 'oplogs', ->
         chai.assert.lengthOf model.Messages.find({id: id, type: 'puzzles'}).fetch(), 1
@@ -102,7 +100,6 @@ describe 'renamePuzzle', ->
         link: 'https://puzzlehunt.mit.edu/foo'
         drive: 'f1'
         spreadsheet: 's1'
-        doc: 'd1'
         tags: {}
       id2 = model.Puzzles.insert
         name: 'Bar'
@@ -116,7 +113,6 @@ describe 'renamePuzzle', ->
         link: 'https://puzzlehunt.mit.edu/foo'
         drive: 'f2'
         spreadsheet: 's2'
-        doc: 'd2'
         tags: {}
       ret = callAs 'renamePuzzle', 'cjb',
         id: id1


### PR DESCRIPTION
Don't create a text document for every puzzle because we don't always need it, but embed it when we manually create one.
Fixes #574 