### PR TITLE
Allow feeding and unfeeding puzzles from the puzzle info pane of metas

### DIFF
--- a/blackboard.less
+++ b/blackboard.less
@@ -149,7 +149,13 @@ body.has-emojis {
 .bb-puzzleround {
   padding-right: 2px; padding-left: 2px;
   .navbar { margin: 0 10px; }
-  table.bb-round-answers { width: auto; }
+  table.bb-round-answers {
+    width: auto;
+    input { margin-top: 0; }
+    .descendant > td:first-child {
+      padding-left: 1em;
+    }
+  }
   .bb-spreadsheet-frame {
     width: 100%;
     height: 500px;

--- a/client/puzzle.app-test.coffee
+++ b/client/puzzle.app-test.coffee
@@ -13,6 +13,40 @@ describe 'puzzle', ->
   after ->
     logout()
 
+  describe 'metameta', ->
+    id = null
+    beforeEach ->
+      await waitForSubscriptions()
+      id = share.model.Puzzles.findOne(name: 'Interstellar Spaceship')._id
+
+    it 'renders puzzle view', ->
+      share.Router.PuzzlePage id, 'puzzle'
+      await waitForSubscriptions()
+      await afterFlushPromise()
+
+    describe 'in info view', ->
+      beforeEach ->
+        share.Router.PuzzlePage id, 'info'
+        await waitForSubscriptions()
+        await afterFlushPromise()
+
+      it 'allows modifying feeders', ->
+        $('.unattached').click()
+        await afterFlushPromise()
+        storm = share.model.Puzzles.findOne(name: 'The Brainstorm')
+        $("[data-feeder-id=\"#{storm._id}\"] input").click()
+        await waitForMethods()
+        chai.assert.include share.model.Puzzles.findOne(id).puzzles, storm._id
+        $("[data-feeder-id=\"#{storm._id}\"] input").click()
+        await waitForMethods()
+        chai.assert.notInclude share.model.Puzzles.findOne(id).puzzles, storm._id
+
+      it 'allows spilling grandfeeders', ->
+        $('.grandfeeders').click()
+        await afterFlushPromise()
+        doors = share.model.Puzzles.findOne(name: 'The Doors Of Cambridge')
+        chai.assert.lengthOf $("[data-feeder-id=\"#{doors._id}\"]").get(), 3
+
   describe 'meta', ->
 
     id = null
@@ -25,10 +59,28 @@ describe 'puzzle', ->
       await waitForSubscriptions()
       await afterFlushPromise()
 
-    it 'renders info view', ->
-      share.Router.PuzzlePage id, 'info'
-      await waitForSubscriptions()
-      await afterFlushPromise()
+    describe 'in info view', ->
+      beforeEach ->
+        share.Router.PuzzlePage id, 'info'
+        await waitForSubscriptions()
+        await afterFlushPromise()
+
+      it 'has no grandfeeders button', ->
+        chai.assert.isNotOk $('.grandfeeders')[0]
+
+      it 'has feeders in order', ->
+        chai.assert.deepEqual share.model.Puzzles.findOne(id).puzzles, $('.bb-round-answers tr[data-feeder-id]').map(-> @dataset.feederId).get()
+
+      it 'allows modifying feeders', ->
+        $('.unattached').click()
+        await afterFlushPromise()
+        storm = share.model.Puzzles.findOne(name: 'The Brainstorm')
+        $("[data-feeder-id=\"#{storm._id}\"] input").click()
+        await waitForMethods()
+        chai.assert.include share.model.Puzzles.findOne(id).puzzles, storm._id
+        $("[data-feeder-id=\"#{storm._id}\"] input").click()
+        await waitForMethods()
+        chai.assert.notInclude share.model.Puzzles.findOne(id).puzzles, storm._id
 
   describe 'leaf', ->
 

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -36,6 +36,7 @@ currentViewIs = (puzzle, view) ->
   return view is possible[0]
 
 Template.puzzle_info.onCreated ->
+  @grandfeeders = new ReactiveVar false
   @autorun =>
     id = Session.get 'id'
     return unless id
@@ -58,6 +59,19 @@ Template.puzzle_info.helpers
     ,
       sort: {created: 1}
   callin_status: -> callin_types.past_status_message @status, @callin_type
+  metameta: ->
+    console.log @puzzle.puzzles
+    model.Puzzles.find({_id: {$in: @puzzle.puzzles}, puzzles: {$exists: true}}).count() > 0
+  grandfeeders: -> Template.instance().grandfeeders.get()
+
+Template.puzzle_info.events
+  'click button.grandfeeders': (event, template) ->
+    template.grandfeeders.set(not event.currentTarget.classList.contains('active'))
+  'change input.feed': (event, template) ->
+    if event.currentTarget.checked
+      Meteor.call 'feedMeta', @_id, Template.currentData().puzzle._id
+    else
+      Meteor.call 'unfeedMeta', @_id, Template.currentData().puzzle._id
 
   unsetcaredabout: ->
     return unless @puzzle

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -37,6 +37,7 @@ currentViewIs = (puzzle, view) ->
 
 Template.puzzle_info.onCreated ->
   @grandfeeders = new ReactiveVar false
+  @unattached = new ReactiveVar false
   @autorun =>
     id = Session.get 'id'
     return unless id
@@ -63,10 +64,14 @@ Template.puzzle_info.helpers
     console.log @puzzle.puzzles
     model.Puzzles.find({_id: {$in: @puzzle.puzzles}, puzzles: {$exists: true}}).count() > 0
   grandfeeders: -> Template.instance().grandfeeders.get()
+  unattached: -> Template.instance().unattached.get()
+  nonfeeders: -> model.Puzzles.find(feedsInto: $size: 0)
 
 Template.puzzle_info.events
   'click button.grandfeeders': (event, template) ->
     template.grandfeeders.set(not event.currentTarget.classList.contains('active'))
+  'click button.unattached': (event, template) ->
+    template.unattached.set(not event.currentTarget.classList.contains('active'))
   'change input.feed': (event, template) ->
     if event.currentTarget.checked
       Meteor.call 'feedMeta', @_id, Template.currentData().puzzle._id

--- a/puzzle.html
+++ b/puzzle.html
@@ -96,15 +96,28 @@
 {{/let}}
 {{#if puzzle.puzzles}}{{#let cares=caresabout}}
 <table class="bb-round-answers table table-bordered table-condensed"><tbody>
-  <tr><th>Puzzle in round</th><th>Answer</th>{{#each cares}}<th>{{name}}</th>{{/each}}</tr>
+  <tr><th>Feeder{{#if metameta}} <button class="btn btn-mini grandfeeders {{#if grandfeeders}}active{{/if}}"><i class="fas fa-sitemap"></i></button>{{/if}}</th><th>Answer</th>{{#each cares}}<th>{{name}}</th>{{/each}}</tr>
   {{#each puzzle.puzzles}}{{#with getPuzzle}}
     <tr>
-      <td>{{>link id=_id}}</td>
+      <td>{{#if grandfeeders}}<input type="checkbox" class="feed" checked="checked">{{/if}}{{>link id=_id}}</td>
       <td class="answer">{{#if solved}}{{tag "answer"}}{{/if}}</td>
       {{#each t in cares}}
         <td>{{tag t.name}}</td>
       {{/each}}
     </tr>
+    {{#if grandfeeders}}
+      {{#each puzzles}}
+        {{#with getPuzzle}}
+          <tr class="descendant">
+            <td><input type="checkbox" class="feed" checked="{{#if includes ../../../../puzzle.puzzles _id}}checked{{/if}}">{{>link id=_id}}</td> 
+            <td class="answer">{{#if solved}}{{tag "answer"}}{{/if}}</td>
+            {{#each t in cares}}
+              <td>{{tag t.name}}</td>
+            {{/each}}
+          </tr>
+          {{/with}}
+      {{/each}}
+    {{/if}}
   {{/with}}{{/each}}
 </tbody></table>
 {{/let}}{{/if}}

--- a/puzzle.html
+++ b/puzzle.html
@@ -96,10 +96,10 @@
 {{/let}}
 {{#if puzzle.puzzles}}{{#let cares=caresabout}}
 <table class="bb-round-answers table table-bordered table-condensed"><tbody>
-  <tr><th>Feeder{{#if metameta}} <button class="btn btn-mini grandfeeders {{#if grandfeeders}}active{{/if}}"><i class="fas fa-sitemap"></i></button>{{/if}}</th><th>Answer</th>{{#each cares}}<th>{{name}}</th>{{/each}}</tr>
+  <tr><th>Feeder <button class="btn btn-mini unattached {{#if unattached}}active{{/if}}"><i class="fas fa-unlink"></i></button>{{#if metameta}}<button class="btn btn-mini grandfeeders {{#if grandfeeders}}active{{/if}}"><i class="fas fa-sitemap"></i></button>{{/if}}</th><th>Answer</th>{{#each cares}}<th>{{name}}</th>{{/each}}</tr>
   {{#each puzzle.puzzles}}{{#with getPuzzle}}
     <tr>
-      <td>{{#if grandfeeders}}<input type="checkbox" class="feed" checked="checked">{{/if}}{{>link id=_id}}</td>
+      <td>{{#if any grandfeeders unattached}}<input type="checkbox" class="feed" checked="checked">{{/if}}{{>link id=_id}}</td>
       <td class="answer">{{#if solved}}{{tag "answer"}}{{/if}}</td>
       {{#each t in cares}}
         <td>{{tag t.name}}</td>
@@ -119,6 +119,19 @@
       {{/each}}
     {{/if}}
   {{/with}}{{/each}}
+  {{#if unattached}}
+    {{#each nonfeeders}}
+      {{#with getPuzzle}}
+        <tr>
+          <td><input type="checkbox" class="feed">{{>link id=_id}}</td> 
+          <td class="answer">{{#if solved}}{{tag "answer"}}{{/if}}</td>
+          {{#each t in cares}}
+            <td>{{tag t.name}}</td>
+          {{/each}}
+        </tr>
+      {{/with}}
+    {{/each}}
+  {{/if}}
 </tbody></table>
 {{/let}}{{/if}}
 </div>

--- a/puzzle.html
+++ b/puzzle.html
@@ -96,7 +96,7 @@
 {{/let}}
 {{#if puzzle.puzzles}}{{#let cares=caresabout}}
 <table class="bb-round-answers table table-bordered table-condensed"><tbody>
-  <tr><th>Feeder <span class="btn-group"><button class="btn btn-mini unattached {{#if unattached}}active{{/if}}"><i class="fas fa-unlink"></i></button>{{#if metameta}}<button class="btn btn-mini grandfeeders {{#if grandfeeders}}active{{/if}}"><i class="fas fa-sitemap"></i></button>{{/if}}</span></th><th>Answer</th>{{#each cares}}<th>{{name}}</th>{{/each}}</tr>
+  <tr><th>Feeder <span class="btn-group"><button title="Show unattached puzzles" class="btn btn-mini unattached {{#if unattached}}active{{/if}}"><i class="fas fa-unlink"></i></button>{{#if metameta}}<button title="Show feeders of feeders" class="btn btn-mini grandfeeders {{#if grandfeeders}}active{{/if}}"><i class="fas fa-sitemap"></i></button>{{/if}}</span></th><th>Answer</th>{{#each cares}}<th>{{name}}</th>{{/each}}</tr>
   {{#each puzzle.puzzles}}{{#with getPuzzle}}
     <tr data-feeder-id="{{_id}}">
       <td>{{#if any grandfeeders unattached}}<input type="checkbox" class="feed" checked="checked">{{/if}}{{>link id=_id}}</td>

--- a/puzzle.html
+++ b/puzzle.html
@@ -96,7 +96,7 @@
 {{/let}}
 {{#if puzzle.puzzles}}{{#let cares=caresabout}}
 <table class="bb-round-answers table table-bordered table-condensed"><tbody>
-  <tr><th>Feeder <button class="btn btn-mini unattached {{#if unattached}}active{{/if}}"><i class="fas fa-unlink"></i></button>{{#if metameta}}<button class="btn btn-mini grandfeeders {{#if grandfeeders}}active{{/if}}"><i class="fas fa-sitemap"></i></button>{{/if}}</th><th>Answer</th>{{#each cares}}<th>{{name}}</th>{{/each}}</tr>
+  <tr><th>Feeder <span class="btn-group"><button class="btn btn-mini unattached {{#if unattached}}active{{/if}}"><i class="fas fa-unlink"></i></button>{{#if metameta}}<button class="btn btn-mini grandfeeders {{#if grandfeeders}}active{{/if}}"><i class="fas fa-sitemap"></i></button>{{/if}}</span></th><th>Answer</th>{{#each cares}}<th>{{name}}</th>{{/each}}</tr>
   {{#each puzzle.puzzles}}{{#with getPuzzle}}
     <tr data-feeder-id="{{_id}}">
       <td>{{#if any grandfeeders unattached}}<input type="checkbox" class="feed" checked="checked">{{/if}}{{>link id=_id}}</td>

--- a/puzzle.html
+++ b/puzzle.html
@@ -98,7 +98,7 @@
 <table class="bb-round-answers table table-bordered table-condensed"><tbody>
   <tr><th>Feeder <button class="btn btn-mini unattached {{#if unattached}}active{{/if}}"><i class="fas fa-unlink"></i></button>{{#if metameta}}<button class="btn btn-mini grandfeeders {{#if grandfeeders}}active{{/if}}"><i class="fas fa-sitemap"></i></button>{{/if}}</th><th>Answer</th>{{#each cares}}<th>{{name}}</th>{{/each}}</tr>
   {{#each puzzle.puzzles}}{{#with getPuzzle}}
-    <tr>
+    <tr data-feeder-id="{{_id}}">
       <td>{{#if any grandfeeders unattached}}<input type="checkbox" class="feed" checked="checked">{{/if}}{{>link id=_id}}</td>
       <td class="answer">{{#if solved}}{{tag "answer"}}{{/if}}</td>
       {{#each t in cares}}
@@ -108,7 +108,7 @@
     {{#if grandfeeders}}
       {{#each puzzles}}
         {{#with getPuzzle}}
-          <tr class="descendant">
+          <tr class="descendant" data-feeder-id="{{_id}}">
             <td><input type="checkbox" class="feed" checked="{{#if includes ../../../../puzzle.puzzles _id}}checked{{/if}}">{{>link id=_id}}</td> 
             <td class="answer">{{#if solved}}{{tag "answer"}}{{/if}}</td>
             {{#each t in cares}}
@@ -122,7 +122,7 @@
   {{#if unattached}}
     {{#each nonfeeders}}
       {{#with getPuzzle}}
-        <tr>
+        <tr data-feeder-id="{{_id}}">
           <td><input type="checkbox" class="feed">{{>link id=_id}}</td> 
           <td class="answer">{{#if solved}}{{tag "answer"}}{{/if}}</td>
           {{#each t in cares}}


### PR DESCRIPTION
A toggle button to show all unattached puzzles, and for metametas, one to show all grandfeeders. When either is toggled, all shown puzzles have a checkbox to control whether it feeds the current meta or not.