### PR TITLE
Use web jitsi interface on mobile

### DIFF
--- a/client/imports/jitsi.js
+++ b/client/imports/jitsi.js
@@ -77,6 +77,7 @@ export function createJitsiMeet(room, container) {
       startWithVideoMuted: START_VIDEO_MUTED.get(),
       prejoinPageEnabled: false,
       enableTalkWhileMuted: false,
+      disableDeepLinking: true,
       "analytics.disabled": true,
     },
   });


### PR DESCRIPTION
Don't show a webpage that says to use the app. Fixes #774