### PR TITLE
Don't subscribe to all rejected callins

### DIFF
--- a/client/callins.js
+++ b/client/callins.js
@@ -9,7 +9,7 @@ Meteor.startup(function () {
 
   // note that this observe 'leaks'; that's ok, the set of callins is small
   Tracker.autorun(function () {
-    const sub = Meteor.subscribe("callins");
+    const sub = Meteor.subscribe("pending-callins");
     if (!sub.ready()) {
       return;
     } // reactive, will re-execute when ready

--- a/client/imports/ui/pages/logistics/logistics.js
+++ b/client/imports/ui/pages/logistics/logistics.js
@@ -49,7 +49,7 @@ Template.logistics.onCreated(function () {
   this.creatingPuzzle = new ReactiveVar(null);
   this.autorun(() => {
     this.subscribe("all-presence");
-    this.subscribe("callins");
+    this.subscribe("pending-callins");
   });
 });
 
@@ -666,6 +666,14 @@ Template.logistics_callins_table.helpers({
       }
     );
   },
+});
+
+Template.logistics_callin_row.onCreated(function () {
+  this.autorun(() => {
+    const data = Template.currentData();
+    if (!data.puzzle) { return; }
+    this.subscribe("callins-by-puzzle", data.puzzle._id);
+  });
 });
 
 Template.logistics_callin_row.helpers({

--- a/client/imports/ui/pages/logistics/logistics.js
+++ b/client/imports/ui/pages/logistics/logistics.js
@@ -671,7 +671,9 @@ Template.logistics_callins_table.helpers({
 Template.logistics_callin_row.onCreated(function () {
   this.autorun(() => {
     const data = Template.currentData();
-    if (!data.puzzle) { return; }
+    if (!data.puzzle) {
+      return;
+    }
     this.subscribe("callins-by-puzzle", data.puzzle._id);
   });
 });

--- a/server/server.js
+++ b/server/server.js
@@ -605,10 +605,10 @@ Meteor.publish(
 );
 
 Meteor.publish(
-  "callins",
+  "pending-callins",
   loginRequired(() =>
     CallIns.find(
-      { status: { $in: ["pending", "rejected"] } },
+      { status: "pending" },
       { sort: [["created", "asc"]] }
     )
   )

--- a/server/server.js
+++ b/server/server.js
@@ -607,10 +607,7 @@ Meteor.publish(
 Meteor.publish(
   "pending-callins",
   loginRequired(() =>
-    CallIns.find(
-      { status: "pending" },
-      { sort: [["created", "asc"]] }
-    )
+    CallIns.find({ status: "pending" }, { sort: [["created", "asc"]] })
   )
 );
 


### PR DESCRIPTION
Remove them from the "callins" publish (now called "pending-callins"). The callin row now subscribes to all callins for the puzzle in question. Fixes #811