### PR TITLE
Allow truncating statistics

### DIFF
--- a/client/imports/router.js
+++ b/client/imports/router.js
@@ -119,7 +119,13 @@ export function FactsPage() {
   Page("facts", "facts", "0", false);
 }
 
-export function StatisticsPage() {
+export function StatisticsPage(ctx) {
+  const params = new URLSearchParams(ctx.querystring);
+  function maybeDate(x) { if (x) { return new Date(x);} return null; }
+  Session.set({
+    start_time: maybeDate(params.get("start_time")),
+    end_time: maybeDate(params.get("end_time")),
+  });
   Page("statistics", "general", "0", false);
 }
 

--- a/client/imports/router.js
+++ b/client/imports/router.js
@@ -121,7 +121,12 @@ export function FactsPage() {
 
 export function StatisticsPage(ctx) {
   const params = new URLSearchParams(ctx.querystring);
-  function maybeDate(x) { if (x) { return new Date(x);} return null; }
+  function maybeDate(x) {
+    if (x) {
+      return new Date(x);
+    }
+    return null;
+  }
   Session.set({
     start_time: maybeDate(params.get("start_time")),
     end_time: maybeDate(params.get("end_time")),

--- a/client/imports/ui/pages/statistics/statistics_chart.js
+++ b/client/imports/ui/pages/statistics/statistics_chart.js
@@ -91,8 +91,12 @@ Template.statistics_chart.onRendered(function () {
         },
         xAxis: {
           type: "time",
-          min () { return Session.get("start_time");},
-          max () { return Session.get("end_time"); },
+          min() {
+            return Session.get("start_time");
+          },
+          max() {
+            return Session.get("end_time");
+          },
         },
       },
       maintainAspectRatio: false,

--- a/client/imports/ui/pages/statistics/statistics_chart.js
+++ b/client/imports/ui/pages/statistics/statistics_chart.js
@@ -91,6 +91,8 @@ Template.statistics_chart.onRendered(function () {
         },
         xAxis: {
           type: "time",
+          min () { return Session.get("start_time");},
+          max () { return Session.get("end_time"); },
         },
       },
       maintainAspectRatio: false,


### PR DESCRIPTION
`start_time` and `end_time` query parameters allow viewing a specific time range, e.g. for a post-hunt report.