### PR TITLE
Support Firefox private browsing mode

### DIFF
--- a/client/imports/serviceworker.js
+++ b/client/imports/serviceworker.js
@@ -1,3 +1,3 @@
-export const registrationPromise = navigator.serviceWorker.register(
+export const registrationPromise = navigator.serviceWorker?.register(
   Meteor._relativeToSiteRootUrl("sw.js")
-);
+) ?? Promise.reject("navigator.serviceWorker is absent");

--- a/client/imports/serviceworker.js
+++ b/client/imports/serviceworker.js
@@ -1,3 +1,3 @@
-export const registrationPromise = navigator.serviceWorker?.register(
-  Meteor._relativeToSiteRootUrl("sw.js")
-) ?? Promise.reject("navigator.serviceWorker is absent");
+export const registrationPromise =
+  navigator.serviceWorker?.register(Meteor._relativeToSiteRootUrl("sw.js")) ??
+  Promise.reject("navigator.serviceWorker is absent");


### PR DESCRIPTION
window.navigator doesn't have a serviceWorker member in Firefox private browsing mode, so don't crash on startup.