### PR TITLE
Fix race condition on presence index

### DIFF
--- a/client/blackboard.js
+++ b/client/blackboard.js
@@ -783,7 +783,7 @@ Template.blackboard_column_body_working.helpers({
     }
     return findByChannel(
       `puzzles/${this.puzzle._id}`,
-      { jitsi: {[jitsi ? "$ne" : "$eq"]: 0} },
+      { jitsi: { [jitsi ? "$ne" : "$eq"]: 0 } },
       { sort: { joined_timestamp: 1 } }
     );
   },

--- a/client/blackboard.js
+++ b/client/blackboard.js
@@ -783,7 +783,7 @@ Template.blackboard_column_body_working.helpers({
     }
     return findByChannel(
       `puzzles/${this.puzzle._id}`,
-      { jitsi },
+      { jitsi: {[jitsi ? "$ne" : "$eq"]: 0} },
       { sort: { joined_timestamp: 1 } }
     );
   },

--- a/client/imports/presence_index.js
+++ b/client/imports/presence_index.js
@@ -16,10 +16,7 @@ Meteor.startup(() =>
     added(doc) {
       ensure(doc.room_name).upsert(doc.nick, {
         $min: { joined_timestamp: doc.joined_timestamp },
-        $max: {
-          jitsi: +(doc.scope === "jitsi"),
-          chat: +(doc.scope === "chat"),
-        },
+        $inc: { [doc.scope]: 1 },
       });
     },
     removed(doc) {
@@ -27,12 +24,7 @@ Meteor.startup(() =>
       if (coll == null) {
         return;
       }
-      coll.update(doc.nick, {
-        $min: {
-          jitsi: +(doc.scope !== "jitsi"),
-          chat: +(doc.scope !== "chat"),
-        },
-      });
+      coll.update(doc.nick, { $inc: { [doc.scope]: -1 } });
       coll.remove({ _id: doc.nick, jitsi: 0, chat: 0 });
     },
   })

--- a/client/imports/ui/pages/logistics/logistics.js
+++ b/client/imports/ui/pages/logistics/logistics.js
@@ -645,7 +645,7 @@ Template.logistics_puzzle_presence.helpers({
   presenceForScope(scope) {
     return findByChannel(
       `puzzles/${this._id}`,
-      { [scope]: 1 },
+      { [scope]: {$ne: 0} },
       { fields: { [scope]: 1 } }
     ).count();
   },

--- a/client/imports/ui/pages/logistics/logistics.js
+++ b/client/imports/ui/pages/logistics/logistics.js
@@ -645,7 +645,7 @@ Template.logistics_puzzle_presence.helpers({
   presenceForScope(scope) {
     return findByChannel(
       `puzzles/${this._id}`,
-      { [scope]: {$ne: 0} },
+      { [scope]: { $ne: 0 } },
       { fields: { [scope]: 1 } }
     ).count();
   },


### PR DESCRIPTION
If you leave and rejoin a room at just the right time, the added and removed messages can get delivered out of order, which meant you were added to a room you were already in, then removed. Now we keep a count of the times you're in the room. Fixes #930