### PR TITLE
Stop propagation at a in editable values

### DIFF
--- a/client/imports/ui/components/edit_field/edit_field.js
+++ b/client/imports/ui/components/edit_field/edit_field.js
@@ -21,7 +21,7 @@ editableTemplate(Template.edit_field, {
 Template.edit_field.events({
   "click a"(event, template) {
     event.stopPropagation();
-  }
+  },
 });
 
 Template.edit_field.helpers({

--- a/client/imports/ui/components/edit_field/edit_field.js
+++ b/client/imports/ui/components/edit_field/edit_field.js
@@ -18,6 +18,12 @@ editableTemplate(Template.edit_field, {
   },
 });
 
+Template.edit_field.events({
+  "click a"(event, template) {
+    event.stopPropagation();
+  }
+});
+
 Template.edit_field.helpers({
   value() {
     return collection(this.type).findOne({ _id: this.id })?.[this.field] ?? "";

--- a/client/imports/ui/components/edit_tag_value/edit_tag_value.js
+++ b/client/imports/ui/components/edit_tag_value/edit_tag_value.js
@@ -48,6 +48,9 @@ Template.edit_tag_value.helpers({
 });
 
 Template.edit_tag_value.events({
+  "click a"(event, template) {
+    event.stopPropagation();
+  },
   'click input[type="color"]'(event, template) {
     event.stopPropagation();
   },


### PR DESCRIPTION
If a field or tag contains a URL-like thing which we have converted to a link, clicking the link shouldn't edit the field/tag.