### PR TITLE
Column options refinements

### DIFF
--- a/client/blackboard.html
+++ b/client/blackboard.html
@@ -196,6 +196,10 @@
   </th>
 </template>
 
+<template name="blackboard_column_header_added">
+  <th class="puzzle-added">Added</th>
+</template>
+
 <template name="blackboard_column_header_update">
   <th class="puzzle-update">Last update</th>
 </template>
@@ -458,8 +462,13 @@
   }}{{/edit_tag_value}}{{!
 }}</template>
 
-<template name="blackboard_column_body_working"><td class="puzzle-working"><div class="in-jitsi" title="In Jitsi">{{#each whos_working 1}}{{> nick_presence }} {{/each}}</div><div class="in-chat" title="In Chat">{{#each whos_working 0}}{{> nick_presence }} {{/each}}</div></td></template>
+<template name="blackboard_column_body_working"><td class="puzzle-working"><div class="in-jitsi {{#if equal whosWorkingStyle "nicks-only"}}comma-list{{/if}}" title="In Jitsi">{{#each whos_working 1}}{{> nick_presence }} {{/each}}</div><div class="in-chat {{#if equal whosWorkingStyle "nicks-only"}}comma-list{{/if}}" title="In Chat">{{#each whos_working 0}}{{> nick_presence }} {{/each}}</div></td></template>
 
+<template name="blackboard_column_body_added">
+  <td class="puzzle-added">
+    {{pretty_ts timestamp=puzzle.created style="brief duration"}}
+  </td>
+</template>
 <template name="blackboard_column_body_update">
   <td class="puzzle-update">
     {{#if puzzle.solved}}solved {{pretty_ts timestamp=puzzle.solved style="brief duration"}}
@@ -467,7 +476,7 @@
     {{else}}
       {{#if stuck puzzle}}stuck since {{pretty_ts timestamp=puzzle.tags.status.touched style="brief duration"}}
       {{else if puzzle.last_partial_answer}}partially solved {{pretty_ts timestamp=puzzle.last_partial_answer style="brief duration"}}
-      {{else}}added {{pretty_ts timestamp=puzzle.created style="brief duration"}}
+      {{else unless columnIsVisible "added"}}added {{pretty_ts timestamp=puzzle.created style="brief duration"}}
       {{/if}}
       {{#if puzzle.drive_touched}}<div class="bb-drive-activity">{{>time_since timestamp=puzzle.drive_touched verb="Active"}} active {{pretty_ts timestamp=puzzle.drive_touched style="brief duration"}}</div>{{/if}}
     {{/if}}
@@ -534,7 +543,7 @@
 
 <template name="nick_presence">
 <span class="nick {{#unless jitsi}}background{{/unless}} {{#if nickNear _id}}near{{/if}}"
-      data-nick="{{_id}}" title="{{nickOrName _id}}{{nickLocation _id}}">{{> gravatar nick=_id size=16 }}</span>
+      data-nick="{{_id}}" title="{{nickOrName _id}}{{nickLocation _id}}">{{#unless equal whosWorkingStyle "nicks-only"}}{{> gravatar nick=_id size=16 }}{{/unless}}{{#unless equal whosWorkingStyle "icons-only"}}{{_id}}{{/unless}}</span>
 </template>
 
 <template name="blackboard_puzzle">

--- a/client/blackboard.less
+++ b/client/blackboard.less
@@ -429,6 +429,10 @@
     }
 
     .puzzle-working {
+      .nick {
+        display: inline-block;
+        img { vertical-align: text-top; }
+      }
       .using-jitsi & {
         .nick.background {
           opacity: 0.6;
@@ -446,7 +450,7 @@
         .in-chat::before { content: '\f086'; }
       }
     }
-    td.puzzle-update {
+    td.puzzle-update, td.puzzle-added {
       font-size: 85%;
     }
   }

--- a/client/imports/settings.js
+++ b/client/imports/settings.js
@@ -131,14 +131,19 @@ Template.registerHelper("nCols", () => 1 + visibleColumns.get().length);
 
 // If iterating over a list without _id fields, the key is index, which makes insertions render oddly.
 Template.registerHelper("visibleColumns", () => visibleColumnsForHelper.get());
-Template.registerHelper("columnIsVisible", col => visibleColumns.get().includes(col));
+Template.registerHelper("columnIsVisible", (col) =>
+  visibleColumns.get().includes(col)
+);
 
 class EnumSetting extends Setting {
   constructor(name, options, defaultValue) {
     super(name);
     this.options = options;
     this.defaultValue = defaultValue;
-    Template.registerHelper(`${name}Options`, Object.entries(options).map(([k, v]) => ({_id: k, ...v})));
+    Template.registerHelper(
+      `${name}Options`,
+      Object.entries(options).map(([k, v]) => ({ _id: k, ...v }))
+    );
   }
   get() {
     return reactiveLocalStorage.getItem(this.name) ?? this.defaultValue;
@@ -154,9 +159,9 @@ export const ICONS_ONLY = "icons-only";
 export const ICONS_AND_NICKNAMES = "icons-and-nicknames";
 export const NICKNAMES_ONLY = "nicknames-only";
 export const WHOS_WORKING_STYLE_OPTIONS = Object.freeze({
-  "icons-only": Object.freeze({display: "Icons Only"}),
-  "icons-and-nicks": Object.freeze({display: "Icons And Nicknames"}),
-  "nicks-only": Object.freeze({display: "Nicknames Only"}),
+  "icons-only": Object.freeze({ display: "Icons Only" }),
+  "icons-and-nicks": Object.freeze({ display: "Icons And Nicknames" }),
+  "nicks-only": Object.freeze({ display: "Nicknames Only" }),
 });
 
 export const WHOS_WORKING_STYLE = new EnumSetting(

--- a/client/imports/settings.js
+++ b/client/imports/settings.js
@@ -156,12 +156,12 @@ class EnumSetting extends Setting {
   }
 }
 export const ICONS_ONLY = "icons-only";
-export const ICONS_AND_NICKNAMES = "icons-and-nicknames";
-export const NICKNAMES_ONLY = "nicknames-only";
+export const ICONS_AND_NICKNAMES = "icons-and-nicks";
+export const NICKNAMES_ONLY = "nicks-only";
 export const WHOS_WORKING_STYLE_OPTIONS = Object.freeze({
-  "icons-only": Object.freeze({ display: "Icons Only" }),
-  "icons-and-nicks": Object.freeze({ display: "Icons And Nicknames" }),
-  "nicks-only": Object.freeze({ display: "Nicknames Only" }),
+  [ICONS_ONLY]: Object.freeze({ display: "Icons Only" }),
+  [ICONS_AND_NICKNAMES]: Object.freeze({ display: "Icons And Nicknames" }),
+  [NICKNAMES_ONLY]: Object.freeze({ display: "Nicknames Only" }),
 });
 
 export const WHOS_WORKING_STYLE = new EnumSetting(

--- a/client/imports/settings.test.js
+++ b/client/imports/settings.test.js
@@ -1,0 +1,29 @@
+import chai from "chai";
+import { ICONS_ONLY, NICKNAMES_ONLY, WHOS_WORKING_STYLE } from "./settings.js";
+
+describe("per-browser settings", function () {
+  describe("EnumSetting", function () {
+    it("rejects non-enum values", function () {
+      chai.assert.throws(() => WHOS_WORKING_STYLE.set("not-in-the-enum"));
+      chai.assert.notEqual(
+        "not-in-the-enum",
+        localStorage.getItem(WHOS_WORKING_STYLE.name)
+      );
+    });
+    it("accepts enum values", function () {
+      WHOS_WORKING_STYLE.set(NICKNAMES_ONLY);
+      chai.assert.equal(
+        NICKNAMES_ONLY,
+        localStorage.getItem(WHOS_WORKING_STYLE.name)
+      );
+    });
+    it("returns from local storage", function () {
+      localStorage.setItem(WHOS_WORKING_STYLE.name, "not in the enum");
+      chai.assert.equal("not in the enum", WHOS_WORKING_STYLE.get());
+    });
+    it("returns default value", function () {
+      localStorage.removeItem(WHOS_WORKING_STYLE.name);
+      chai.assert.equal(ICONS_ONLY, WHOS_WORKING_STYLE.get());
+    });
+  });
+});

--- a/client/options_dropdown.html
+++ b/client/options_dropdown.html
@@ -39,18 +39,25 @@
           Hide solved Favorites
         </label>
       </a></li>
-      <li><a name="bb-compact-mode">
-        <label class="checkbox bb-compact-mode" title="Hide all info except puzzle name, links, and solution">
-          <input type="checkbox" name="bb-compact-mode" checked="{{compactMode}}">
-          Compact mode
-        </label>
-      </a></li>
       <li class="dropdown-submenu">
-        <a name="custom-columns">Visible Columns</a>
-        <ul class="dropdown-menu">
+        <a name="custom-columns">Column Settings</a>
+        <ul class="dropdown-menu nav-list">
+          <li class="disabled"><a name="name-column"><label class="checkbox">
+              <input type="checkbox" checked="checked" disabled="disabled">Name</label></a></li>
+          <li class="indent"><a name="bb-compact-mode">
+            <label class="checkbox bb-compact-mode" title="Hide tags and other metas fed by puzzles">
+              <input type="checkbox" name="bb-compact-mode" checked="{{compactMode}}">
+              Hide Tags
+            </label>
+          </a></li>
           {{#options_dropdown_column_checkbox column="answer"}}Solution{{/options_dropdown_column_checkbox}}
           {{#options_dropdown_column_checkbox column="status"}}Status{{/options_dropdown_column_checkbox}}
           {{#options_dropdown_column_checkbox column="working"}}Working On This{{/options_dropdown_column_checkbox}}
+          <li class="disabled indent"><a name="nick-display-options">Display Style:</a></li>
+          {{#each style in whosWorkingStyleOptions}}
+            <li class="indent"><a name="{{style._id}}-option"><label class="radio"><input type="radio" name="whos-working-display-style" value="{{style._id}}" checked="{{equal whosWorkingStyle style._id}}">{{style.display}}</label></a></li>
+          {{/each}}
+          {{#options_dropdown_column_checkbox column="added"}}Added{{/options_dropdown_column_checkbox}}
           {{#options_dropdown_column_checkbox column="update"}}Last Update{{/options_dropdown_column_checkbox}}
         </ul>
       </li>
@@ -100,7 +107,7 @@
 
 <template name="options_dropdown_column_checkbox">
   <!-- data context is name of column, i.e. what's after "puzzle-" in the class -->
-  <li><a name="answer-column"><label class="checkbox">
+  <li><a name="{{column}}-column"><label class="checkbox">
     <input data-column-visibility="{{column}}" type="checkbox" checked="{{columnVisible}}">
     {{> Template.contentBlock}}
   </label></a></li>

--- a/client/options_dropdown.js
+++ b/client/options_dropdown.js
@@ -13,6 +13,7 @@ import {
   START_AUDIO_MUTED,
   COMPACT_MODE,
   CURRENT_COLUMNS,
+  WHOS_WORKING_STYLE,
 } from "./imports/settings.js";
 
 Template.options_dropdown.helpers({
@@ -72,6 +73,9 @@ Template.options_dropdown.events({
         })
         .get()
     );
+  },
+  'change input[name="whos-working-display-style"]'(event, template) {
+    WHOS_WORKING_STYLE.set(event.target.value);
   },
 });
 

--- a/client/options_dropdown.less
+++ b/client/options_dropdown.less
@@ -1,4 +1,7 @@
 .bb-display-settings .dropdown-submenu .dropdown-menu {
   left: unset;
   right: calc(100% + 13px);
+  li.indent a {
+    padding-left: 30px;
+  }
 }


### PR DESCRIPTION
* Rename "Visible Columns" submenu to "Column Options".
* Add Name as a disabled setting in "Column Options" since you can't hide it.
* Rename "Compact Mode" to "Hide Tags" and nest under "Name"
* Add "Added" column, hidden by default.
* Add display style option for "Who's Working"

Fixes #1327