### PR TITLE
Delete dynamic_no_whitespace

### DIFF
--- a/client/chat.html
+++ b/client/chat.html
@@ -159,7 +159,7 @@ Click here to stay in this meeting instead.{{/if}}">
 </template>
 
 <template name="chat_format_body">
-  {{#each chunk in chunks}}{{>dynamic_no_whitespace template=(chunk_template chunk.type) data=chunk.content}}{{/each}}
+  {{#each chunk in chunks}}{{>Template.dynamic template=(chunk_template chunk.type) data=chunk.content}}{{/each}}
 </template>
 
 <template name="poll">

--- a/client/text_chunk.html
+++ b/client/text_chunk.html
@@ -1,12 +1,5 @@
 
-<template name="dynamic_no_whitespace">{{
-  #with chooseTemplate template}}{{
-    # .. ../data}}{{
-      > Template.contentBlock}}{{
-    / ..}}{{
-  /with}}</template>
-
-<template name="text_chunks">{{#each chunk in chunks}}{{>dynamic_no_whitespace template=(concat "text_chunk_" chunk.type) data=chunk.content}}{{/each}}</template>
+<template name="text_chunks">{{#each chunk in chunks}}{{>Template.dynamic template=(concat "text_chunk_" chunk.type) data=chunk.content}}{{/each}}</template>
 
 <template name="text_chunk_break"><br></template>
 

--- a/client/text_chunk.js
+++ b/client/text_chunk.js
@@ -36,9 +36,3 @@ Template.text_chunk_url_image.helpers({
     return url.match(/(\.|format=)(png|jpg|jpeg|gif)$/i);
   },
 });
-
-Template.dynamic_no_whitespace.helpers({
-  chooseTemplate(name) {
-    return Blaze._getTemplate(name, () => Template.instance());
-  },
-});


### PR DESCRIPTION
My PR to Blaze was accepted, so this is now the default behavior for `Template.dynamic`.