### PR TITLE
Fix favorite mechanic check with strict mode

### DIFF
--- a/client/mechanics.js
+++ b/client/mechanics.js
@@ -2,6 +2,7 @@ import { mechanics } from "/lib/imports/mechanics.js";
 import floatingDropdown from "/client/imports/ui/mixins/floating_dropdown";
 
 Template.registerHelper("yourFavoriteMechanic", function () {
+  "use strict"; // otherwise, this is new String("mechanic"), not "mechanic"
   return Meteor.user().favorite_mechanics?.includes(this);
 });
 


### PR DESCRIPTION
The .includes check doesn't work without strict mode because the helper
function gets called with .apply, so that `this` is a String object
rather than a primitive string.

(Maybe strict mode should just be enabled everywhere? Looks like it was
lost during decaffeination in #752.)