### PR TITLE
Autocomplete room name after room type

### DIFF
--- a/client/chat.app-test.js
+++ b/client/chat.app-test.js
@@ -411,7 +411,7 @@ describe("chat", function () {
         chai.assert.equal(0, typeahead.length);
       });
 
-      it("completes room name", async function () {
+      it("completes room id", async function () {
         const id = Puzzles.findOne({ name: "Space Elevator" })._id;
         const recipe = Puzzles.findOne({ name: "Cooking a Recipe" })._id;
         ChatPage("puzzles", id);
@@ -424,6 +424,72 @@ describe("chat", function () {
         $(`a[data-value="puzzles/${recipe}"]`).click();
         await afterFlushPromise();
         chai.assert.equal(input.val(), `#puzzles/${recipe} `);
+        const typeahead = $("#messageInputTypeahead");
+        chai.assert.equal(0, typeahead.length);
+      });
+
+      it("completes puzzle room id", async function () {
+        const id = Puzzles.findOne({ name: "Space Elevator" })._id;
+        const recipe = Puzzles.findOne({ name: "Cooking a Recipe" })._id;
+        ChatPage("puzzles", id);
+        await waitForSubscriptions();
+        await afterFlushPromise();
+        const input = $("#messageInput");
+        input.val(`#puzzles/Cook`);
+        input.click();
+        await afterFlushPromise();
+        $(`a[data-value="puzzles/${recipe}"]`).click();
+        await afterFlushPromise();
+        chai.assert.equal(input.val(), `#puzzles/${recipe} `);
+        const typeahead = $("#messageInputTypeahead");
+        chai.assert.equal(0, typeahead.length);
+      });
+
+      it("doesn't need hash for puzzles", async function () {
+        const id = Puzzles.findOne({ name: "Space Elevator" })._id;
+        const recipe = Puzzles.findOne({ name: "Cooking a Recipe" })._id;
+        ChatPage("puzzles", id);
+        await waitForSubscriptions();
+        await afterFlushPromise();
+        const input = $("#messageInput");
+        input.val(`#Cook`);
+        input.click();
+        await afterFlushPromise();
+        $(`a[data-value="puzzles/${recipe}"]`).click();
+        await afterFlushPromise();
+        chai.assert.equal(input.val(), `#puzzles/${recipe} `);
+        const typeahead = $("#messageInputTypeahead");
+        chai.assert.equal(0, typeahead.length);
+      });
+
+      it("completes round room id", async function () {
+        const id = Rounds.findOne({ name: "Civilization" })._id;
+        ChatPage("puzzles", id);
+        await waitForSubscriptions();
+        await afterFlushPromise();
+        const input = $("#messageInput");
+        input.val(`#rounds/ivil`);
+        input.click();
+        await afterFlushPromise();
+        $(`a[data-value="rounds/${id}"]`).click();
+        await afterFlushPromise();
+        chai.assert.equal(input.val(), `#rounds/${id} `);
+        const typeahead = $("#messageInputTypeahead");
+        chai.assert.equal(0, typeahead.length);
+      });
+
+      it("doesn't need hash for rounds", async function () {
+        const id = Rounds.findOne({ name: "Civilization" })._id;
+        ChatPage("puzzles", id);
+        await waitForSubscriptions();
+        await afterFlushPromise();
+        const input = $("#messageInput");
+        input.val(`#ivil`);
+        input.click();
+        await afterFlushPromise();
+        $(`a[data-value="rounds/${id}"]`).click();
+        await afterFlushPromise();
+        chai.assert.equal(input.val(), `#rounds/${id} `);
         const typeahead = $("#messageInputTypeahead");
         chai.assert.equal(0, typeahead.length);
       });

--- a/client/chat.js
+++ b/client/chat.js
@@ -884,10 +884,10 @@ Template.messages_input.onCreated(function () {
       this.selected.set(null);
       return;
     }
-    const qdoc = { $regex: query, $options: "i" };
     let c, l;
     switch (type) {
       case "users":
+        const qdoc = { $regex: query, $options: "i" };
         c = Meteor.users.find(
           { $or: [{ _id: qdoc }, { real_name: qdoc }] },
           {
@@ -899,12 +899,19 @@ Template.messages_input.onCreated(function () {
         l = c.map((x) => x._id);
         break;
       case "rooms":
-        const orList = [{ name: qdoc }];
+        let orList;
         const [type, id] = query.split("/", 2);
         if (!id) {
-          orList.push({ type: { $regex: type, $options: "i" } });
+          orList = [
+            { type: { $regex: type, $options: "i" } },
+            { type: { $in: ["rounds", "puzzles"] }, _id: { $regex: type, $options: "i" }},
+            { type: { $in: ["rounds", "puzzles"] }, name: { $regex: type, $options: "i" } },
+          ];
         } else {
-          orList.push({ type, _id: { $regex: id, $options: "i" } });
+          orList = [
+            { type, _id: { $regex: id, $options: "i" } },
+            { type, name: { $regex: id, $options: "i" } },
+          ];
         }
         c = Names.find(
           { $or: orList },

--- a/client/chat.js
+++ b/client/chat.js
@@ -904,8 +904,14 @@ Template.messages_input.onCreated(function () {
         if (!id) {
           orList = [
             { type: { $regex: type, $options: "i" } },
-            { type: { $in: ["rounds", "puzzles"] }, _id: { $regex: type, $options: "i" }},
-            { type: { $in: ["rounds", "puzzles"] }, name: { $regex: type, $options: "i" } },
+            {
+              type: { $in: ["rounds", "puzzles"] },
+              _id: { $regex: type, $options: "i" },
+            },
+            {
+              type: { $in: ["rounds", "puzzles"] },
+              name: { $regex: type, $options: "i" },
+            },
           ];
         } else {
           orList = [


### PR DESCRIPTION
if you type `#puzzles/foo` match puzzles with foo in their name. Previously that would only match puzzles with foo in their id, but #foo would match anything with foo in its name.

Fixes #1387