### PR TITLE
Detect permission change

### DIFF
--- a/client/imports/notification.js
+++ b/client/imports/notification.js
@@ -129,8 +129,8 @@ Meteor.startup(async function () {
     Session.set("notifications", "denied");
     return;
   }
-  const perm = await navigator.permissions.query({name: "notifications"});
-  function permCheck () {
+  const perm = await navigator.permissions.query({ name: "notifications" });
+  function permCheck() {
     Session.set("notifications", perm.state);
     if (perm.state === "granted") {
       setupNotifications();


### PR DESCRIPTION
Seems like this doesn't happen on localhost, but on a remote host Notification.permission can be "default" on startup, then change to "granted". That makes us think we have to ask, so the button says "enable" but clicking it works instantly because they're already enabled.

Intended to fix #1395