### PR TITLE
Always check the return value of botuser()

### DIFF
--- a/client/chat.js
+++ b/client/chat.js
@@ -285,7 +285,7 @@ Template.messages.helpers({
     // test Session.get('nobot') last to get a fine-grained dependency
     // on the `nobot` session variable only for 'useless' messages
     const myNick = Meteor.userId();
-    const botnick = botuser()._id;
+    const botnick = botuser()?._id;
     if (m.nick === myNick) {
       return true;
     }
@@ -1121,8 +1121,11 @@ Template.messages_input.onCreated(function () {
           }
           if (to === "bot") {
             // allow 'bot' as a shorthand for 'codexbot'
-            to = botuser()._id;
-            continue;
+            const bot = botuser();
+            if (bot) {
+              to = bot._id;
+              continue;
+            }
           }
           [extra, rest] = rest.split(/\s+([^]*)/, 2);
           to += " " + extra;

--- a/client/geolocation.js
+++ b/client/geolocation.js
@@ -102,7 +102,7 @@ Template.registerHelper("nickLocation", function (args) {
   if (canonical(args.nick) === Meteor.userId()) {
     return "";
   } // that's me!
-  if (args.nick === botuser()._id) {
+  if (args.nick === botuser()?._id) {
     const idx = Math.floor(Session.get("currentTime") / (10 * 60 * 1000));
     return ` is ${CODEXBOT_LOCATIONS[idx % CODEXBOT_LOCATIONS.length]}`;
   }


### PR DESCRIPTION
Since chat messages and users are separate subscriptions, there's no guaranteeing the users load first, which could mean botuser() initially returns null, so check its value to prevent exceptions on page load.