### PR TITLE
Clean up some indices on the Message collection

### DIFF
--- a/lib/imports/collections.js
+++ b/lib/imports/collections.js
@@ -238,19 +238,16 @@ export var Messages = (BBCollection.messages = new Mongo.Collection(
   "messages"
 ));
 if (Meteor.isServer) {
-  Messages.createIndex({ to: 1, room_name: 1, timestamp: -1 }, {});
   Messages.createIndex(
     { to: 1, timestamp: -1 },
     { partialFilterExpression: { to: { $exists: true } } }
   );
-  Messages.createIndex({ nick: 1, room_name: 1, timestamp: -1 }, {});
   Messages.createIndex({ room_name: 1, timestamp: -1 }, {});
   Messages.createIndex(
     { room_name: 1, starred: -1, timestamp: 1 },
     { partialFilterExpression: { starred: true } }
   );
-  Messages.createIndex({ timestamp: 1 }, {});
-  Messages.createIndex({ mention: 1 }, {});
+  Messages.createIndex({ mention: 1 }, { partialFilterExpression: { mention: { $exists: true }}, name: "mentions_if_present"});
   Messages.createIndex(
     { announced_at: 1 },
     { partialFilterExpression: { announced_at: { $exists: true } } }

--- a/lib/imports/collections.js
+++ b/lib/imports/collections.js
@@ -247,7 +247,13 @@ if (Meteor.isServer) {
     { room_name: 1, starred: -1, timestamp: 1 },
     { partialFilterExpression: { starred: true } }
   );
-  Messages.createIndex({ mention: 1 }, { partialFilterExpression: { mention: { $exists: true }}, name: "mentions_if_present"});
+  Messages.createIndex(
+    { mention: 1 },
+    {
+      partialFilterExpression: { mention: { $exists: true } },
+      name: "mentions_if_present",
+    }
+  );
   Messages.createIndex(
     { announced_at: 1 },
     { partialFilterExpression: { announced_at: { $exists: true } } }


### PR DESCRIPTION
{to, room_name, timestamp} and {nick, room_name, timestamp} were added with the expectection that the room subscription would use them, but Mongodb prefers to use the use the {room_name, timestamp} index and filter out the few private messages, which makes sense because they're rare.

{timestamp} was only used by the Hubot observer, but I changed that to use Mongo's native change stream (to not keep the messages in memory) so it's no longer used.

{mention{ should always have had a partial filter expression since we never want to search for messages that don't mention anybody.

Fixes #1435 