### PR TITLE
Use white-space: -moz-pre-space in chat input

### DIFF
--- a/client/chat.less
+++ b/client/chat.less
@@ -448,6 +448,7 @@ table.poll {
   min-height: 30px;
   background-color: var(--bg-color);
   padding: 5px;
+  white-space: -moz-pre-space;
   &:empty::before {
     content: attr(data-placeholder);
     user-select: none;


### PR DESCRIPTION
Should make its trailing space behavior more consistent with other browsers, e.g. not stripping them out randomly.

Fixes #1583