### PR TITLE
Make new round button not a button

### DIFF
--- a/client/imports/ui/pages/logistics/logistics.html
+++ b/client/imports/ui/pages/logistics/logistics.html
@@ -5,7 +5,7 @@
         <div class="bb-logistics-controls">
           <div class="btn-group">
             <span class="btn btn-mini btn-success disabled active"><i class="fas fa-plus"></i> New</span>
-            <button id="bb-logistics-new-round" class="btn btn-mini btn-inverse {{#if creatingRound}}open{{/if}}">
+            <span id="bb-logistics-new-round" class="btn btn-mini btn-inverse {{#if creatingRound}}open{{/if}}">
               <i class="fas fa-folder-open"></i> Round
               {{#if creatingRound}}
                 <ul class="dropdown-menu stay-open">
@@ -18,7 +18,7 @@
                   <li><a data-create-placeholder-meta="true">With Placeholder Meta</a></li>
                 </ul>
               {{/if}}
-            </button>
+            </span>
             <button id="bb-logistics-new-meta" class="btn btn-mini btn-primary" data-toggle="dropdown" data-target="#bb-logistics-new-meta">
               <i class="fas fa-filter"></i> Meta
               {{>logistics_round_menu}}


### PR DESCRIPTION
Buttons click on space, and we don't want to because hte round name might contain one.

Fixes #1585