### PR TITLE
Simplify install.sh user/group creation

### DIFF
--- a/ops/scripts/install.sh
+++ b/ops/scripts/install.sh
@@ -37,8 +37,9 @@ sudo apt-get install -y mongodb-org nodejs software-properties-common
 sudo npm install -g handlebars-cmd
 cd "$scriptroot"/../..
 
-sudo addgroup blackboard
-sudo useradd -G blackboard -m blackboard
+# Don't crash if user reruns the install script and we try making the same user
+# more than once
+sudo useradd -m blackboard || true
 
 # Build the bundle, then install it.
 meteor npm install


### PR DESCRIPTION
These lines were crashing the install script for me, I think because useradd also tries creating the group of the same name and fails because it already exists. It also makes it hard to restart an install that crashed after these lines, since it's not idempotent.

This might slightly change how the blackboard user and group are set up in practice from the existing code but I couldn't see where this matters.