### PR TITLE
Update to hubot 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "favico.js": "^0.3.10",
         "gemoji": "^8.1.0",
         "google-auth-library": "^10.6.2",
-        "hubot": "^9.0.0",
+        "hubot": "^10.0.5",
         "hubot-help": "^2.1.5",
         "mail-listener6": "^2.0.3",
         "md5": "^2.3.0",
@@ -2855,14 +2855,6 @@
         "node": ">= 16"
       }
     },
-    "node_modules/cline": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/cline/-/cline-0.8.2.tgz",
-      "integrity": "sha512-xcRdiR3vm9XdLmsMkK3XkKOHzOmKxl8eVTO739O6KinC0kRdCGV4jYnItccNMReymKYhQ9obOlMscic5spP3mQ==",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/coffeescript": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
@@ -4536,16 +4528,15 @@
       }
     },
     "node_modules/hubot": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/hubot/-/hubot-9.0.0.tgz",
-      "integrity": "sha512-Kqh02e2GfpejX4H7/958XcgHPE21y8dL3qpP+60VeAjcKZx/k9GagdEq4UsKYAY6yiK+KVTi5qBMNjKlmTmw8w==",
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/hubot/-/hubot-10.0.5.tgz",
+      "integrity": "sha512-vs6PuWb4B+7ZtUEUozF0rT5jQxHLPovTZ0MeTZ1TpRx4jTvLY0cZBIBBVjr09iSnuIhqRQD5QSA0NBBZhqypdA==",
+      "license": "MIT",
       "dependencies": {
-        "cline": "^0.8.2",
         "coffeescript": "^2.7.0",
         "connect-multiparty": "^2.2.0",
         "express": "^4.18.2",
         "express-basic-auth": "^1.2.1",
-        "optparse": "^1.0.5",
         "pino": "^8.11.0"
       },
       "bin": {
@@ -6791,11 +6782,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/optparse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/optparse/-/optparse-1.0.5.tgz",
-      "integrity": "sha512-WfnNWLS3vr8omCm8nKYKaRbapuy6pEbx1O0B+eP5sUf/a++sT9/h8PflqBoHsY9N+YdzUT12T8snXigq13QpJg=="
     },
     "node_modules/p-limit": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "favico.js": "^0.3.10",
     "gemoji": "^8.1.0",
     "google-auth-library": "^10.6.2",
-    "hubot": "^9.0.0",
+    "hubot": "^10.0.5",
     "hubot-help": "^2.1.5",
     "mail-listener6": "^2.0.3",
     "md5": "^2.3.0",

--- a/server/hubot.js
+++ b/server/hubot.js
@@ -22,6 +22,7 @@ if (DO_BATCH_PROCESSING) {
 
   Meteor.startup(async function () {
     const robot = new Robot(BOTNAME, BOT_GRAVATAR);
+    await robot.run();
     // register scripts
     robot.privately(hubot_help);
     robot.loadExternalScripts(EXTERNAL_SCRIPTS);
@@ -33,7 +34,5 @@ if (DO_BATCH_PROCESSING) {
       console.log(`Loading hubot script: ${name}`);
       await script(robot);
     }
-
-    await robot.run();
   });
 }


### PR DESCRIPTION
Can't go to hubot 11+ because meteor compiles the node modules, which is incompatible with .mjs files.